### PR TITLE
syntax: fix syntax error in file_explorer

### DIFF
--- a/atomic-assembler/atomic_assembler/screens/file_explorer.py
+++ b/atomic-assembler/atomic_assembler/screens/file_explorer.py
@@ -146,7 +146,7 @@ class FileExplorerScreen(Screen):
         if list_view.item:
             # self.current_path = str(list_view.highlighted_item.item_data["path"])
             self.current_path_widget.update(
-                f"Current directory: [bold {PRIMARY_COLOR}]{list_view.item.item_data["path"]}[/bold {PRIMARY_COLOR}]"
+                f"Current directory: [bold {PRIMARY_COLOR}]{list_view.item.item_data['path']}[/bold {PRIMARY_COLOR}]"
             )
 
     def _get_file_items(self):


### PR DESCRIPTION
Syntax error in the file_explorer resulting in the following error 

```
Traceback (most recent call last):
  File "/Users/jima/comware/workspace/atomica/.venv/bin/atomic", line 5, in <module>
    from atomic_assembler.main import main
  File "/Users/jima/comware/workspace/atomica/.venv/lib/python3.11/site-packages/atomic_assembler/main.py", line 5, in <module>
    from atomic_assembler.app import AtomicAssembler
  File "/Users/jima/comware/workspace/atomica/.venv/lib/python3.11/site-packages/atomic_assembler/app.py", line 9, in <module>
    from atomic_assembler.screens.file_explorer import FileExplorerScreen
  File "/Users/jima/comware/workspace/atomica/.venv/lib/python3.11/site-packages/atomic_assembler/screens/file_explorer.py", line 149
    f"Current directory: [bold {PRIMARY_COLOR}]{list_view.item.item_data["path"]}[/bold {PRIMARY_COLOR}]"
 ```