### PR TITLE
added delete by turn id

### DIFF
--- a/atomic-agents/atomic_agents/lib/components/agent_memory.py
+++ b/atomic-agents/atomic_agents/lib/components/agent_memory.py
@@ -135,7 +135,8 @@ class AgentMemory:
         if not self.history:
             self.current_turn_id = None
         elif turn_id == self.current_turn_id:
-            self.current_turn_id = max(msg.turn_id for msg in self.history)
+            # Always update to the last message's turn_id
+            self.current_turn_id = self.history[-1].turn_id
 
         return f"Successfully deleted message with turn ID {turn_id}."
 

--- a/atomic-agents/atomic_agents/lib/components/agent_memory.py
+++ b/atomic-agents/atomic_agents/lib/components/agent_memory.py
@@ -112,6 +112,33 @@ class AgentMemory:
         """
         return self.current_turn_id
 
+    def delete_turn_id(self, turn_id: int) -> str:
+        """
+        Delete a message from the memory by its turn ID.
+
+        Args:
+            turn_id (int): The turn ID of the message to delete.
+
+        Returns:
+            str: A success message with the deleted turn ID.
+
+        Raises:
+            ValueError: If the specified turn ID is not found in the memory.
+        """
+        initial_length = len(self.history)
+        self.history = [msg for msg in self.history if msg.turn_id != turn_id]
+
+        if len(self.history) == initial_length:
+            raise ValueError(f"Turn ID {turn_id} not found in memory.")
+
+        # Update current_turn_id if necessary
+        if not self.history:
+            self.current_turn_id = None
+        elif turn_id == self.current_turn_id:
+            self.current_turn_id = max(msg.turn_id for msg in self.history)
+
+        return f"Successfully deleted message with turn ID {turn_id}."
+
     def get_message_count(self) -> int:
         """
         Returns the number of messages in the chat history.

--- a/atomic-agents/atomic_agents/lib/components/agent_memory.py
+++ b/atomic-agents/atomic_agents/lib/components/agent_memory.py
@@ -112,9 +112,9 @@ class AgentMemory:
         """
         return self.current_turn_id
 
-    def delete_turn_id(self, turn_id: int) -> str:
+    def delete_turn_id(self, turn_id: int):
         """
-        Delete a message from the memory by its turn ID.
+        Delete messages from the memory by its turn ID.
 
         Args:
             turn_id (int): The turn ID of the message to delete.
@@ -132,13 +132,11 @@ class AgentMemory:
             raise ValueError(f"Turn ID {turn_id} not found in memory.")
 
         # Update current_turn_id if necessary
-        if not self.history:
+        if not len(self.history):
             self.current_turn_id = None
         elif turn_id == self.current_turn_id:
             # Always update to the last message's turn_id
             self.current_turn_id = self.history[-1].turn_id
-
-        return f"Successfully deleted message with turn ID {turn_id}."
 
     def get_message_count(self) -> int:
         """

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -247,3 +247,43 @@ def test_serialize_non_baseioschema():
     memory = AgentMemory()
     result = memory._serialize_content("Not a BaseIOSchema")
     assert result == "Not a BaseIOSchema"
+
+def test_agent_memory_delete_turn_id(memory):
+    mock_input = TestInputSchema(test_field="Test input")
+    mock_output = TestInputSchema(test_field="Test output")
+  
+    memory = AgentMemory()
+    initial_turn_id = "123-456"
+    memory.current_turn_id = initial_turn_id
+
+    # Add a message with a specific turn ID
+    memory.add_message(
+        "user",
+        mock_input,  
+    )
+    memory.history[-1].turn_id = initial_turn_id
+    
+    # Add another message with a different turn ID
+    other_turn_id = "789-012"
+    memory.add_message(
+        "assistant",
+        mock_output,
+    )
+    memory.history[-1].turn_id = other_turn_id
+    
+    # Act & Assert: Delete the message with initial_turn_id and verify
+    success_message = memory.delete_turn_id(initial_turn_id)
+    assert success_message == f"Successfully deleted message with turn ID {initial_turn_id}."
+
+    # The remaining message in memory should have the other_turn_id
+    assert len(memory.history) == 1
+    assert memory.history[0].turn_id == other_turn_id
+
+    # If we delete the last message, current_turn_id should become None
+    memory.delete_turn_id(other_turn_id)
+    assert memory.current_turn_id is None
+    assert len(memory.history) == 0
+
+    # Assert: Trying to delete a non-existing turn ID should raise a ValueError
+    with pytest.raises(ValueError, match="Turn ID non-existent-id not found in memory."):
+        memory.delete_turn_id("non-existent-id")

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -248,10 +248,11 @@ def test_serialize_non_baseioschema():
     result = memory._serialize_content("Not a BaseIOSchema")
     assert result == "Not a BaseIOSchema"
 
+
 def test_agent_memory_delete_turn_id(memory):
     mock_input = TestInputSchema(test_field="Test input")
     mock_output = TestInputSchema(test_field="Test output")
-  
+
     memory = AgentMemory()
     initial_turn_id = "123-456"
     memory.current_turn_id = initial_turn_id
@@ -259,10 +260,10 @@ def test_agent_memory_delete_turn_id(memory):
     # Add a message with a specific turn ID
     memory.add_message(
         "user",
-        mock_input,  
+        mock_input,
     )
     memory.history[-1].turn_id = initial_turn_id
-    
+
     # Add another message with a different turn ID
     other_turn_id = "789-012"
     memory.add_message(
@@ -270,10 +271,9 @@ def test_agent_memory_delete_turn_id(memory):
         mock_output,
     )
     memory.history[-1].turn_id = other_turn_id
-    
+
     # Act & Assert: Delete the message with initial_turn_id and verify
-    success_message = memory.delete_turn_id(initial_turn_id)
-    assert success_message == f"Successfully deleted message with turn ID {initial_turn_id}."
+    memory.delete_turn_id(initial_turn_id)
 
     # The remaining message in memory should have the other_turn_id
     assert len(memory.history) == 1


### PR DESCRIPTION
Agent Memory Added a new proc to delete by turn id
When using search tool , we add search as system message to memory and there is no way to delete only this turn id for next conversion, so added method called delete_turn_id by passing turn_id we can delete the particular message from memory

Added all the conditions like empty memory, last message , invalid turn id