### PR TITLE
Add support for arbitary image keys for multi modal queries

### DIFF
--- a/atomic-agents/atomic_agents/lib/components/agent_memory.py
+++ b/atomic-agents/atomic_agents/lib/components/agent_memory.py
@@ -49,9 +49,9 @@ class AgentMemory:
         self.current_turn_id = str(uuid.uuid4())
 
     def add_message(
-            self,
-            role: str,
-            content: BaseIOSchema,
+        self,
+        role: str,
+        content: BaseIOSchema,
     ) -> None:
         """
         Adds a message to the chat history and manages overflow.
@@ -257,14 +257,12 @@ if __name__ == "__main__":
     from typing import List as TypeList, Dict as TypeDict
     import os
 
-
     # Define complex test schemas
     class NestedSchema(BaseIOSchema):
         """A nested schema for testing"""
 
         nested_field: str = Field(..., description="A nested field")
         nested_int: int = Field(..., description="A nested integer")
-
 
     class ComplexInputSchema(BaseIOSchema):
         """Complex Input Schema"""
@@ -274,7 +272,6 @@ if __name__ == "__main__":
         list_field: TypeList[str] = Field(..., description="A list of strings")
         nested_field: NestedSchema = Field(..., description="A nested schema")
 
-
     class ComplexOutputSchema(BaseIOSchema):
         """Complex Output Schema"""
 
@@ -282,14 +279,12 @@ if __name__ == "__main__":
         calculated_value: int = Field(..., description="A calculated value")
         data_dict: TypeDict[str, NestedSchema] = Field(..., description="A dictionary of nested schemas")
 
-
     # Add a new multimodal schema for testing
     class MultimodalSchema(BaseIOSchema):
         """Schema for testing multimodal content"""
 
         instruction_text: str = Field(..., description="The instruction text")
         images: List[instructor.Image] = Field(..., description="The images to analyze")
-
 
     # Create and populate the original memory with complex data
     original_memory = AgentMemory(max_messages=10)

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -297,5 +297,36 @@ def test_get_history_with_multimodal_content(memory):
     assert len(history) == 1
     assert history[0]["role"] == "user"
     assert isinstance(history[0]["content"], list)
-    assert history[0]["content"][0] == "Analyze this image"
+    assert history[0]["content"][0] == '{"instruction_text": "Analyze this image"}'
     assert history[0]["content"][1] == mock_image
+
+
+def test_get_history_with_multiple_images_multimodal_content(memory):
+    """Test that get_history correctly handles multimodal content"""
+
+    class TestMultimodalSchemaArbitraryKeys(BaseIOSchema):
+        """Test schema for multimodal content"""
+
+        instruction_text: str = Field(..., description="The instruction text")
+        some_key_for_images: List[instructor.Image] = Field(..., description="The images to analyze")
+        some_other_key_with_image: instructor.Image = Field(..., description="The images to analyze")
+
+    # Create a mock image
+    mock_image = instructor.Image(source="test_url", media_type="image/jpeg", detail="low")
+    mock_image_2 = instructor.Image(source="test_url_2", media_type="image/jpeg", detail="low")
+    mock_image_3 = instructor.Image(source="test_url_3", media_type="image/jpeg", detail="low")
+
+    # Add a multimodal message
+    memory.add_message("user", TestMultimodalSchemaArbitraryKeys(instruction_text="Analyze this image",
+                                                                 some_other_key_with_image=mock_image,
+                                                                 some_key_for_images=[mock_image_2, mock_image_3]))
+
+    # Get history and verify format
+    history = memory.get_history()
+    assert len(history) == 1
+    assert history[0]["role"] == "user"
+    assert isinstance(history[0]["content"], list)
+    assert history[0]["content"][0] == '{"instruction_text": "Analyze this image"}'
+    assert mock_image in history[0]["content"]
+    assert mock_image_2 in history[0]["content"]
+    assert mock_image_3 in history[0]["content"]

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -317,9 +317,14 @@ def test_get_history_with_multiple_images_multimodal_content(memory):
     mock_image_3 = instructor.Image(source="test_url_3", media_type="image/jpeg", detail="low")
 
     # Add a multimodal message
-    memory.add_message("user", TestMultimodalSchemaArbitraryKeys(instruction_text="Analyze this image",
-                                                                 some_other_key_with_image=mock_image,
-                                                                 some_key_for_images=[mock_image_2, mock_image_3]))
+    memory.add_message(
+        "user",
+        TestMultimodalSchemaArbitraryKeys(
+            instruction_text="Analyze this image",
+            some_other_key_with_image=mock_image,
+            some_key_for_images=[mock_image_2, mock_image_3],
+        ),
+    )
 
     # Get history and verify format
     history = memory.get_history()


### PR DESCRIPTION
Currently the only way to add images is to put them in the "images" key of the InputSchema to send them to the model.
Further in the current implementation we can only have 1 text description for the image, but for my use case the image is just a small part of a larger analysis, so I think it would be better to be able to add the full payload like in the normal text queries instead of silently swallowing the rest.

Not sure if I misunderstand something w.r.t multi-modality, but I don't see any other way for my use case.

**Caveats**

I had to edit one test for all the tests to pass, because before just the image description was sent to the model not the full dumped json like in the "text only" queries.

TODO:
~Found the dev-guide, will fix the issues~