### PR TITLE
Add atomic-agents to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyfiglet>=1.0.2,<2.0.0
 textual>=0.82.0,<1.0.0
 pyyaml>=6.0.2,<7.0.0
 requests>=2.32.3,<3.0.0
+atomic-agents


### PR DESCRIPTION
If using `pip install -r requirements.txt` rather than poetry, the quickstart example failed due to a missing `atomic-agents` package: 

```
(venv) atomic-examples % python quickstart/quickstart/1_basic_chatbot.py 
Traceback (most recent call last):
  File "tmp/atomic-agents/atomic-examples/quickstart/quickstart/1_basic_chatbot.py", line 7, in <module>
    from atomic_agents.lib.components.agent_memory import AgentMemory
ModuleNotFoundError: No module named 'atomic_agents'
```

Unsure which version numbers to recommend so that's omitted!