### PR TITLE
Bugfix model_dump when searizling message content in history

### DIFF
--- a/atomic-agents/atomic_agents/lib/components/agent_memory.py
+++ b/atomic-agents/atomic_agents/lib/components/agent_memory.py
@@ -121,7 +121,7 @@ class AgentMemory:
                 history.append({"role": message.role, "content": [json.dumps(message_content), *images]})
             else:
                 # For regular content, serialize to JSON string
-                history.append({"role": message.role, "content": json.dumps(content.model_dump())})
+                history.append({"role": message.role, "content": json.dumps(content.model_dump(mode="json"))})
         return history
 
     def copy(self) -> "AgentMemory":


### PR DESCRIPTION
# What

Currently in `atomic_agents.lib.components.agent_memory.AgentMemory`, when we do `model_dump` pydantic serialization, it defaults to `mode="python"`. The default python mode serialization fails to serialize some files like `HttpUrl` when doing `json.dumps`, which throws serialization error.

For example, this throws error:
```python
from pydantic import HttpUrl

json.dumps(HttpUrl('https://example.com/')) # throws error in json.dumps
```

Full Traceback on my end when running a simple agent:

```python
File ~/path/to/base_agent.py:189, in BaseAgent.run(self, user_input)
    186     self.current_user_input = user_input
    187     self.memory.add_message("user", user_input)
--> 189 response = self.get_response(response_model=self.output_schema)
    190 self.memory.add_message("assistant", response)
    192 return response

File ~/path/to/base_agent.py:163, in BaseAgent.get_response(self, response_model)
    155 if response_model is None:
    156     response_model = self.output_schema
    158 messages = [
    159     {
    160         "role": "system",
    161         "content": self.system_prompt_generator.generate_prompt(),
    162     }
--> 163 ] + self.memory.get_history()
    165 response = self.client.chat.completions.create(
    166     messages=messages,
    167     model=self.model,
    168     response_model=response_model,
    169     **self.model_api_parameters,
    170 )
    172 return response

File ~/path/to/agent_memory.py:124, in AgentMemory.get_history(self)
    121         history.append({"role": message.role, "content": [json.dumps(message_content), *images]})
    122     else:
    123         # For regular content, serialize to JSON string
--> 124         history.append({"role": message.role, "content": json.dumps(content.model_dump())})
    125 return history

File ~/python/path/json/__init__.py:231, in dumps(obj, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)
    226 # cached encoder
    227 if (not skipkeys and ensure_ascii and
    228     check_circular and allow_nan and
    229     cls is None and indent is None and separators is None and
    230     default is None and not sort_keys and not kw):
--> 231     return _default_encoder.encode(obj)
    232 if cls is None:
    233     cls = JSONEncoder

File ~/python/path/json/encoder.py:200, in JSONEncoder.encode(self, o)
    196         return encode_basestring(o)
    197 # This doesn't pass the iterator directly to ''.join() because the
    198 # exceptions aren't as detailed.  The list call should be roughly
    199 # equivalent to the PySequence_Fast that ''.join() would do.
--> 200 chunks = self.iterencode(o, _one_shot=True)
    201 if not isinstance(chunks, (list, tuple)):
    202     chunks = list(chunks)

File ~/python/path/json/encoder.py:258, in JSONEncoder.iterencode(self, o, _one_shot)
    253 else:
    254     _iterencode = _make_iterencode(
    255         markers, self.default, _encoder, self.indent, floatstr,
    256         self.key_separator, self.item_separator, self.sort_keys,
    257         self.skipkeys, _one_shot)
--> 258 return _iterencode(o, 0)

File ~/python/path/json/encoder.py:180, in JSONEncoder.default(self, o)
    161 def default(self, o):
    162     """Implement this method in a subclass such that it returns
    163     a serializable object for ``o``, or calls the base implementation
    164     (to raise a ``TypeError``).
   (...)
    178 
    179     """
--> 180     raise TypeError(f'Object of type {o.__class__.__name__} '
    181                     f'is not JSON serializable')

TypeError: Object of type HttpUrl is not JSON serializable

```

# Fixes


Using `model_dump(mode="json")` instead of default "python". This solves the serialization issue. 

---

@KennyVaneetvelde 

