### PR TITLE
Added system_role to BaseAgentConfig

### DIFF
--- a/atomic-agents/atomic_agents/agents/base_agent.py
+++ b/atomic-agents/atomic_agents/agents/base_agent.py
@@ -160,19 +160,19 @@ class BaseAgent:
             response_model = self.output_schema
 
         if self.system_role is None:
-            messages = []
+            self.messages = []
         else:
-            messages = [
+            self.messages = [
                 {
                     "role": self.system_role,
                     "content": self.system_prompt_generator.generate_prompt(),
                 }
             ]
 
-        messages += self.memory.get_history()
+        self.messages += self.memory.get_history()
 
         response = self.client.chat.completions.create(
-            messages=messages,
+            messages=self.messages,
             model=self.model,
             response_model=response_model,
             **self.model_api_parameters,

--- a/atomic-agents/atomic_agents/agents/base_agent.py
+++ b/atomic-agents/atomic_agents/agents/base_agent.py
@@ -65,7 +65,9 @@ class BaseAgentConfig(BaseModel):
     system_prompt_generator: Optional[SystemPromptGenerator] = Field(
         None, description="Component for generating system prompts."
     )
-    system_role: Optional[str] = Field("system", description="The role of the system in the conversation. None means no system prompt.")
+    system_role: Optional[str] = Field(
+        "system", description="The role of the system in the conversation. None means no system prompt."
+    )
     input_schema: Optional[Type[BaseModel]] = Field(None, description="The schema for the input data.")
     output_schema: Optional[Type[BaseModel]] = Field(None, description="The schema for the output data.")
     model_config = {"arbitrary_types_allowed": True}
@@ -166,7 +168,7 @@ class BaseAgent:
                     "content": self.system_prompt_generator.generate_prompt(),
                 }
             ]
-        
+
         messages += self.memory.get_history()
 
         response = self.client.chat.completions.create(

--- a/atomic-agents/tests/agents/test_base_agent.py
+++ b/atomic-agents/tests/agents/test_base_agent.py
@@ -92,6 +92,7 @@ def test_initialization_without_temperature(mock_instructor, mock_memory, mock_s
     agent = BaseAgent(config)
     assert agent.model_api_parameters["temperature"] == 0.5
 
+
 def test_initialization_without_max_tokens(mock_instructor, mock_memory, mock_system_prompt_generator):
     config = BaseAgentConfig(
         client=mock_instructor,
@@ -103,6 +104,7 @@ def test_initialization_without_max_tokens(mock_instructor, mock_memory, mock_sy
     )
     agent = BaseAgent(config)
     assert agent.model_api_parameters["max_tokens"] == 1024
+
 
 def test_initialization_system_role_equals_developer(mock_instructor, mock_memory, mock_system_prompt_generator):
     config = BaseAgentConfig(
@@ -117,6 +119,7 @@ def test_initialization_system_role_equals_developer(mock_instructor, mock_memor
     _ = agent.get_response()
     assert isinstance(agent.messages, list) and agent.messages[0]["role"] == "developer"
 
+
 def test_initialization_system_role_equals_None(mock_instructor, mock_memory, mock_system_prompt_generator):
     config = BaseAgentConfig(
         client=mock_instructor,
@@ -129,6 +132,7 @@ def test_initialization_system_role_equals_None(mock_instructor, mock_memory, mo
     agent = BaseAgent(config)
     _ = agent.get_response()
     assert isinstance(agent.messages, list) and len(agent.messages) == 0
+
 
 def test_reset_memory(agent, mock_memory):
     initial_memory = agent.initial_memory

--- a/atomic-agents/tests/agents/test_base_agent.py
+++ b/atomic-agents/tests/agents/test_base_agent.py
@@ -80,6 +80,56 @@ def test_initialization_temperature_priority(mock_instructor, mock_memory, mock_
     assert agent.model_api_parameters["temperature"] == 1.0
 
 
+def test_initialization_without_temperature(mock_instructor, mock_memory, mock_system_prompt_generator):
+    config = BaseAgentConfig(
+        client=mock_instructor,
+        model="gpt-4o-mini",
+        memory=mock_memory,
+        system_prompt_generator=mock_system_prompt_generator,
+        temperature=0.5,
+        model_api_parameters={},  # No temperature specified
+    )
+    agent = BaseAgent(config)
+    assert agent.model_api_parameters["temperature"] == 0.5
+
+def test_initialization_without_max_tokens(mock_instructor, mock_memory, mock_system_prompt_generator):
+    config = BaseAgentConfig(
+        client=mock_instructor,
+        model="gpt-4o-mini",
+        memory=mock_memory,
+        system_prompt_generator=mock_system_prompt_generator,
+        max_tokens=1024,
+        model_api_parameters={},  # No temperature specified
+    )
+    agent = BaseAgent(config)
+    assert agent.model_api_parameters["max_tokens"] == 1024
+
+def test_initialization_system_role_equals_developer(mock_instructor, mock_memory, mock_system_prompt_generator):
+    config = BaseAgentConfig(
+        client=mock_instructor,
+        model="gpt-4o-mini",
+        memory=mock_memory,
+        system_prompt_generator=mock_system_prompt_generator,
+        system_role="developer",
+        model_api_parameters={},  # No temperature specified
+    )
+    agent = BaseAgent(config)
+    _ = agent.get_response()
+    assert isinstance(agent.messages, list) and agent.messages[0]["role"] == "developer"
+
+def test_initialization_system_role_equals_None(mock_instructor, mock_memory, mock_system_prompt_generator):
+    config = BaseAgentConfig(
+        client=mock_instructor,
+        model="gpt-4o-mini",
+        memory=mock_memory,
+        system_prompt_generator=mock_system_prompt_generator,
+        system_role=None,
+        model_api_parameters={},  # No temperature specified
+    )
+    agent = BaseAgent(config)
+    _ = agent.get_response()
+    assert isinstance(agent.messages, list) and len(agent.messages) == 0
+
 def test_reset_memory(agent, mock_memory):
     initial_memory = agent.initial_memory
     agent.reset_memory()

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -7,7 +7,7 @@ from atomic_agents.lib.base.base_io_schema import BaseIOSchema
 import instructor
 
 
-class TestInputSchema(BaseIOSchema):
+class InputSchema(BaseIOSchema):
     """Test Input Schema"""
 
     test_field: str = Field(..., description="A test field")
@@ -67,22 +67,22 @@ def test_initialize_turn(memory):
 
 
 def test_add_message(memory):
-    memory.add_message("user", TestInputSchema(test_field="Hello"))
+    memory.add_message("user", InputSchema(test_field="Hello"))
     assert len(memory.history) == 1
     assert memory.history[0].role == "user"
-    assert isinstance(memory.history[0].content, TestInputSchema)
+    assert isinstance(memory.history[0].content, InputSchema)
     assert memory.history[0].turn_id is not None
 
 
 def test_manage_overflow(memory):
     for i in range(7):
-        memory.add_message("user", TestInputSchema(test_field=f"Message {i}"))
+        memory.add_message("user", InputSchema(test_field=f"Message {i}"))
     assert len(memory.history) == 5
     assert memory.history[0].content.test_field == "Message 2"
 
 
 def test_get_history(memory):
-    memory.add_message("user", TestInputSchema(test_field="Hello"))
+    memory.add_message("user", InputSchema(test_field="Hello"))
     memory.add_message("assistant", TestOutputSchema(test_field="Hi there"))
     history = memory.get_history()
     assert len(history) == 2
@@ -91,7 +91,7 @@ def test_get_history(memory):
 
 
 def test_copy(memory):
-    memory.add_message("user", TestInputSchema(test_field="Hello"))
+    memory.add_message("user", InputSchema(test_field="Hello"))
     copied_memory = memory.copy()
     assert copied_memory.max_messages == memory.max_messages
     assert copied_memory.current_turn_id == memory.current_turn_id
@@ -108,7 +108,7 @@ def test_get_current_turn_id(memory):
 
 def test_get_message_count(memory):
     assert memory.get_message_count() == 0
-    memory.add_message("user", TestInputSchema(test_field="Hello"))
+    memory.add_message("user", InputSchema(test_field="Hello"))
     assert memory.get_message_count() == 1
 
 
@@ -150,9 +150,9 @@ def test_load_invalid_data(memory):
 
 
 def test_get_class_from_string():
-    class_string = "tests.lib.components.test_agent_memory.TestInputSchema"
+    class_string = "tests.lib.components.test_agent_memory.InputSchema"
     cls = AgentMemory._get_class_from_string(class_string)
-    assert cls.__name__ == TestInputSchema.__name__
+    assert cls.__name__ == InputSchema.__name__
     assert cls.__module__.endswith("test_agent_memory")
     assert issubclass(cls, BaseIOSchema)
 
@@ -163,9 +163,9 @@ def test_get_class_from_string_invalid():
 
 
 def test_message_model():
-    message = Message(role="user", content=TestInputSchema(test_field="Test"), turn_id="123")
+    message = Message(role="user", content=InputSchema(test_field="Test"), turn_id="123")
     assert message.role == "user"
-    assert isinstance(message.content, TestInputSchema)
+    assert isinstance(message.content, InputSchema)
     assert message.turn_id == "123"
 
 
@@ -209,7 +209,7 @@ def test_complex_scenario(memory):
     assert new_memory.history[1].content.data_dict["key1"].nested_field == "Nested output 1"
 
     # Add a new message to the loaded memory
-    new_memory.add_message("user", TestInputSchema(test_field="New message"))
+    new_memory.add_message("user", InputSchema(test_field="New message"))
     assert len(new_memory.history) == 3
     assert new_memory.history[2].content.test_field == "New message"
 
@@ -217,14 +217,14 @@ def test_complex_scenario(memory):
 def test_memory_with_no_max_messages():
     unlimited_memory = AgentMemory()
     for i in range(100):
-        unlimited_memory.add_message("user", TestInputSchema(test_field=f"Message {i}"))
+        unlimited_memory.add_message("user", InputSchema(test_field=f"Message {i}"))
     assert len(unlimited_memory.history) == 100
 
 
 def test_memory_with_zero_max_messages():
     zero_max_memory = AgentMemory(max_messages=0)
     for i in range(10):
-        zero_max_memory.add_message("user", TestInputSchema(test_field=f"Message {i}"))
+        zero_max_memory.add_message("user", InputSchema(test_field=f"Message {i}"))
     assert len(zero_max_memory.history) == 0
 
 
@@ -232,7 +232,7 @@ def test_memory_turn_consistency():
     memory = AgentMemory()
     memory.initialize_turn()
     turn_id = memory.get_current_turn_id()
-    memory.add_message("user", TestInputSchema(test_field="Hello"))
+    memory.add_message("user", InputSchema(test_field="Hello"))
     memory.add_message("assistant", TestOutputSchema(test_field="Hi"))
     assert memory.history[0].turn_id == turn_id
     assert memory.history[1].turn_id == turn_id
@@ -240,13 +240,13 @@ def test_memory_turn_consistency():
     memory.initialize_turn()
     new_turn_id = memory.get_current_turn_id()
     assert new_turn_id != turn_id
-    memory.add_message("user", TestInputSchema(test_field="Next turn"))
+    memory.add_message("user", InputSchema(test_field="Next turn"))
     assert memory.history[2].turn_id == new_turn_id
 
 
 def test_agent_memory_delete_turn_id(memory):
-    mock_input = TestInputSchema(test_field="Test input")
-    mock_output = TestInputSchema(test_field="Test output")
+    mock_input = InputSchema(test_field="Test input")
+    mock_output = InputSchema(test_field="Test output")
 
     memory = AgentMemory()
     initial_turn_id = "123-456"

--- a/atomic-examples/quickstart/quickstart/5_custom_system_role_for_reasoning_models.py
+++ b/atomic-examples/quickstart/quickstart/5_custom_system_role_for_reasoning_models.py
@@ -3,7 +3,7 @@ import instructor
 import openai
 from rich.console import Console
 from rich.text import Text
-from atomic_agents.agents.base_agent import BaseAgent, BaseAgentConfig, BaseAgentInputSchema, BaseAgentOutputSchema
+from atomic_agents.agents.base_agent import BaseAgent, BaseAgentConfig, BaseAgentInputSchema
 from atomic_agents.lib.components.system_prompt_generator import SystemPromptGenerator
 
 # API Key setup
@@ -26,7 +26,7 @@ client = instructor.from_openai(openai.OpenAI(api_key=API_KEY))
 sysyem_prompt_generator = SystemPromptGenerator(
     background=["You are a math genious."],
     steps=["Think logically step by step and solve a math problem."],
-    output_instructions=["Answer in plain English plus formulas."]
+    output_instructions=["Answer in plain English plus formulas."],
 )
 # Agent setup with specified configuration
 agent = BaseAgent(
@@ -36,7 +36,7 @@ agent = BaseAgent(
         sysyem_prompt_generator=sysyem_prompt_generator,
         # It is a convention to use "developer" as the system role for reasoning models from OpenAI such as o1, o3-mini.
         # Also these models are often used without a system prompt, which you can do by setting system_role=None
-        system_role="developer"
+        system_role="developer",
     )
 )
 

--- a/atomic-examples/quickstart/quickstart/5_custom_system_role_for_reasoning_models.py
+++ b/atomic-examples/quickstart/quickstart/5_custom_system_role_for_reasoning_models.py
@@ -1,0 +1,54 @@
+import os
+import instructor
+import openai
+from rich.console import Console
+from rich.text import Text
+from atomic_agents.agents.base_agent import BaseAgent, BaseAgentConfig, BaseAgentInputSchema, BaseAgentOutputSchema
+from atomic_agents.lib.components.system_prompt_generator import SystemPromptGenerator
+
+# API Key setup
+API_KEY = ""
+if not API_KEY:
+    API_KEY = os.getenv("OPENAI_API_KEY")
+
+if not API_KEY:
+    raise ValueError(
+        "API key is not set. Please set the API key as a static variable or in the environment variable OPENAI_API_KEY."
+    )
+
+# Initialize a Rich Console for pretty console outputs
+console = Console()
+
+# OpenAI client setup using the Instructor library
+client = instructor.from_openai(openai.OpenAI(api_key=API_KEY))
+
+# System prompt generator setup
+sysyem_prompt_generator = SystemPromptGenerator(
+    background=["You are a math genious."],
+    steps=["Think logically step by step and solve a math problem."],
+    output_instructions=["Answer in plain English plus formulas."]
+)
+# Agent setup with specified configuration
+agent = BaseAgent(
+    config=BaseAgentConfig(
+        client=client,
+        model="o3-mini",
+        sysyem_prompt_generator=sysyem_prompt_generator,
+        # It is a convention to use "developer" as the system role for reasoning models from OpenAI such as o1, o3-mini.
+        # Also these models are often used without a system prompt, which you can do by setting system_role=None
+        system_role="developer"
+    )
+)
+
+# Prompt the user for input with a styled prompt
+user_input = "Decompose this number to prime factors: 1234567890"
+console.print(Text("User:", style="bold green"), end=" ")
+console.print(user_input)
+
+# Process the user's input through the agent and get the response
+input_schema = BaseAgentInputSchema(chat_message=user_input)
+response = agent.run(input_schema)
+
+agent_message = Text(response.chat_message, style="bold green")
+console.print(Text("Agent:", style="bold green"), end=" ")
+console.print(agent_message)


### PR DESCRIPTION
I propose to add system_role to BaseAgentConfig.
`system_role: Optional[str] = Field("system", description="The role of the system in the conversation. None means no system prompt.")
`
In some thinking-type models, it's a convention to use a different role for the system prompt or not to use a system prompt.
