### PR TITLE
change ollama client mode to json

### DIFF
--- a/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
+++ b/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
@@ -44,7 +44,9 @@ def setup_client(provider):
     elif provider == "4" or provider == "ollama":
         from openai import OpenAI as OllamaClient
 
-        client = instructor.from_openai(OllamaClient(base_url="http://localhost:11434/v1", api_key="ollama"))
+        client = instructor.from_openai(
+            OllamaClient(base_url="http://localhost:11434/v1", api_key="ollama"), mode=instructor.Mode.JSON
+        )
         model = "llama3"
     elif provider == "5" or provider == "gemini":
         from openai import OpenAI


### PR DESCRIPTION
Fix issue 102 where in `atomic_examples/quickstart/quickstart/4_basic_chatbot_different_providers.py` the ollama model selection was not working.

I fixed the issue by changing the mode to json.