### PR TITLE
changed model_api_parameters to api_parameters

### DIFF
--- a/atomic-agents/atomic_agents/agents/base_agent.py
+++ b/atomic-agents/atomic_agents/agents/base_agent.py
@@ -68,7 +68,7 @@ class BaseAgentConfig(BaseModel):
         "system", description="The role of the system in the conversation. None means no system prompt."
     )
     model_config = {"arbitrary_types_allowed": True}
-    model_api_parameters: Optional[dict] = Field(None, description="Additional parameters passed to the API provider.")
+    api_parameters: Optional[dict] = Field(None, description="Additional parameters passed to the API provider.")
 
 
 class BaseAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
@@ -90,7 +90,7 @@ class BaseAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
         system_role (Optional[str]): The role of the system in the conversation. None means no system prompt.
         initial_memory (AgentMemory): Initial state of the memory.
         current_user_input (Optional[InputSchema]): The current user input being processed.
-        model_api_parameters (dict): Additional parameters passed to the API provider.
+        api_parameters (dict): Additional parameters passed to the API provider.
             - Use this for parameters like 'temperature', 'max_tokens', etc.
     """
 
@@ -108,7 +108,7 @@ class BaseAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
         self.system_role = config.system_role
         self.initial_memory = self.memory.copy()
         self.current_user_input = None
-        self.model_api_parameters = config.model_api_parameters or {}
+        self.api_parameters = config.api_parameters or {}
 
     def reset_memory(self):
         """
@@ -170,7 +170,7 @@ class BaseAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
             messages=self.messages,
             model=self.model,
             response_model=self.output_schema,
-            **self.model_api_parameters,
+            **self.api_parameters,
         )
         self.memory.add_message("assistant", response)
 
@@ -203,7 +203,7 @@ class BaseAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
             model=self.model,
             messages=self.messages,
             response_model=self.output_schema,
-            **self.model_api_parameters,
+            **self.api_parameters,
             stream=True,
         )
 
@@ -238,7 +238,7 @@ class BaseAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
         self._prepare_messages()
 
         response = await self.client.chat.completions.create(
-            model=self.model, messages=self.messages, response_model=self.output_schema, **self.model_api_parameters
+            model=self.model, messages=self.messages, response_model=self.output_schema, **self.api_parameters
         )
 
         self.memory.add_message("assistant", response)
@@ -266,7 +266,7 @@ class BaseAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
             model=self.model,
             messages=self.messages,
             response_model=self.output_schema,
-            **self.model_api_parameters,
+            **self.api_parameters,
             stream=True,
         )
 

--- a/atomic-agents/tests/agents/test_base_agent.py
+++ b/atomic-agents/tests/agents/test_base_agent.py
@@ -109,20 +109,20 @@ def test_initialization(agent, mock_instructor, mock_memory, mock_system_prompt_
     assert agent.model == "gpt-4o-mini"
     assert agent.memory == mock_memory
     assert agent.system_prompt_generator == mock_system_prompt_generator
-    assert "max_tokens" not in agent.model_api_parameters
+    assert "max_tokens" not in agent.api_parameters
 
 
-# model_api_parameters should have priority over other settings
+# api_parameters should have priority over other settings
 def test_initialization_temperature_priority(mock_instructor, mock_memory, mock_system_prompt_generator):
     config = BaseAgentConfig(
         client=mock_instructor,
         model="gpt-4o-mini",
         memory=mock_memory,
         system_prompt_generator=mock_system_prompt_generator,
-        model_api_parameters={"temperature": 1.0},
+        api_parameters={"temperature": 1.0},
     )
     agent = BaseAgent[BaseAgentInputSchema, BaseAgentOutputSchema](config)
-    assert agent.model_api_parameters["temperature"] == 1.0
+    assert agent.api_parameters["temperature"] == 1.0
 
 
 def test_initialization_without_temperature(mock_instructor, mock_memory, mock_system_prompt_generator):
@@ -131,10 +131,10 @@ def test_initialization_without_temperature(mock_instructor, mock_memory, mock_s
         model="gpt-4o-mini",
         memory=mock_memory,
         system_prompt_generator=mock_system_prompt_generator,
-        model_api_parameters={"temperature": 0.5},
+        api_parameters={"temperature": 0.5},
     )
     agent = BaseAgent[BaseAgentInputSchema, BaseAgentOutputSchema](config)
-    assert agent.model_api_parameters["temperature"] == 0.5
+    assert agent.api_parameters["temperature"] == 0.5
 
 
 def test_initialization_without_max_tokens(mock_instructor, mock_memory, mock_system_prompt_generator):
@@ -143,10 +143,10 @@ def test_initialization_without_max_tokens(mock_instructor, mock_memory, mock_sy
         model="gpt-4o-mini",
         memory=mock_memory,
         system_prompt_generator=mock_system_prompt_generator,
-        model_api_parameters={"max_tokens": 1024},
+        api_parameters={"max_tokens": 1024},
     )
     agent = BaseAgent[BaseAgentInputSchema, BaseAgentOutputSchema](config)
-    assert agent.model_api_parameters["max_tokens"] == 1024
+    assert agent.api_parameters["max_tokens"] == 1024
 
 
 def test_initialization_system_role_equals_developer(mock_instructor, mock_memory, mock_system_prompt_generator):
@@ -156,7 +156,7 @@ def test_initialization_system_role_equals_developer(mock_instructor, mock_memor
         memory=mock_memory,
         system_prompt_generator=mock_system_prompt_generator,
         system_role="developer",
-        model_api_parameters={},  # No temperature specified
+        api_parameters={},  # No temperature specified
     )
     agent = BaseAgent[BaseAgentInputSchema, BaseAgentOutputSchema](config)
     _ = agent._prepare_messages()
@@ -170,7 +170,7 @@ def test_initialization_system_role_equals_None(mock_instructor, mock_memory, mo
         memory=mock_memory,
         system_prompt_generator=mock_system_prompt_generator,
         system_role=None,
-        model_api_parameters={},  # No temperature specified
+        api_parameters={},  # No temperature specified
     )
     agent = BaseAgent[BaseAgentInputSchema, BaseAgentOutputSchema](config)
     _ = agent._prepare_messages()

--- a/atomic-examples/deep-research/deep_research/agents/choice_agent.py
+++ b/atomic-examples/deep-research/deep_research/agents/choice_agent.py
@@ -45,7 +45,7 @@ choice_agent = BaseAgent[ChoiceAgentInputSchema, ChoiceAgentOutputSchema](
                 "Your decision must match your reasoning - don't contradict yourself",
             ],
         ),
-        model_api_parameters={"temperature": 0.1},
+        api_parameters={"temperature": 0.1},
     )
 )
 

--- a/atomic-examples/deep-research/deep_research/agents/qa_agent.py
+++ b/atomic-examples/deep-research/deep_research/agents/qa_agent.py
@@ -57,6 +57,6 @@ question_answering_agent = BaseAgent[QuestionAnsweringAgentInputSchema, Question
                 "- What are the limitations of your search capabilities?",
             ],
         ),
-        model_api_parameters={"temperature": 0.1},
+        api_parameters={"temperature": 0.1},
     )
 )

--- a/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
+++ b/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
@@ -80,7 +80,7 @@ client, model = setup_client(provider)
 
 # Agent setup with specified configuration
 agent = BaseAgent[BaseAgentInputSchema, BaseAgentOutputSchema](
-    config=BaseAgentConfig(client=client, model=model, memory=memory, model_api_parameters={"max_tokens": 2048})
+    config=BaseAgentConfig(client=client, model=model, memory=memory, api_parameters={"max_tokens": 2048})
 )
 
 # Generate the default system prompt for the agent

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -136,7 +136,7 @@ class BaseAgentConfig:
     system_prompt_generator: Optional[SystemPromptGenerator] = None  # Prompt generator
     input_schema: Optional[Type[BaseModel]] = None  # Custom input schema
     output_schema: Optional[Type[BaseModel]] = None  # Custom output schema
-    model_api_parameters: Optional[dict] = None  # Additional API parameters
+    api_parameters: Optional[dict] = None  # Additional API parameters
 ```
 
 ### Input/Output Schemas

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -35,7 +35,7 @@ agent = BaseAgent[BaseAgentInputSchema, BaseAgentOutputSchema](
         client=instructor.from_openai(OpenAI(api_key=os.getenv("OPENAI_API_KEY"))),
         model="gpt-4-turbo-preview",
         memory=memory,
-        model_api_parameters={"max_tokens": 2048}
+        api_parameters={"max_tokens": 2048}
     )
 )
 
@@ -291,7 +291,7 @@ agent = BaseAgent[BaseAgentInputSchema, BaseAgentOutputSchema](
     config=BaseAgentConfig(
         client=client,
         model=model,
-        model_api_parameters={"max_tokens": 2048}
+        api_parameters={"max_tokens": 2048}
     )
 )
 ```


### PR DESCRIPTION
I changed `model_api_parameters` of `BaseAgentConfig` to `api_parameters`. This field caused warnings because any field names starting with `model_` have been reserved by `Pydantic`.