### PR TITLE
Pydantic Pyright error

### DIFF
--- a/atomic-agents/atomic_agents/agents/base_agent.py
+++ b/atomic-agents/atomic_agents/agents/base_agent.py
@@ -60,26 +60,26 @@ class BaseAgentOutputSchema(BaseIOSchema):
 
 class BaseAgentConfig(BaseModel):
     client: instructor.client.Instructor = Field(..., description="Client for interacting with the language model.")
-    model: str = Field("gpt-4o-mini", description="The model to use for generating responses.")
-    memory: Optional[AgentMemory] = Field(None, description="Memory component for storing chat history.")
+    model: str = Field(default="gpt-4o-mini", description="The model to use for generating responses.")
+    memory: Optional[AgentMemory] = Field(default=None, description="Memory component for storing chat history.")
     system_prompt_generator: Optional[SystemPromptGenerator] = Field(
-        None, description="Component for generating system prompts."
+        default=None, description="Component for generating system prompts."
     )
     system_role: Optional[str] = Field(
-        "system", description="The role of the system in the conversation. None means no system prompt."
+        default="system", description="The role of the system in the conversation. None means no system prompt."
     )
-    input_schema: Optional[Type[BaseModel]] = Field(None, description="The schema for the input data.")
-    output_schema: Optional[Type[BaseModel]] = Field(None, description="The schema for the output data.")
+    input_schema: Optional[Type[BaseModel]] = Field(default=None, description="The schema for the input data.")
+    output_schema: Optional[Type[BaseModel]] = Field(default=None, description="The schema for the output data.")
     model_config = {"arbitrary_types_allowed": True}
     temperature: Optional[float] = Field(
-        None,
+        default=None,
         description="Temperature for response generation, typically ranging from 0 to 1.",
     )
     max_tokens: Optional[int] = Field(
-        None,
+        default=None,
         description="Maximum number of token allowed in the response generation.",
     )
-    model_api_parameters: Optional[dict] = Field(None, description="Additional parameters passed to the API provider.")
+    model_api_parameters: Optional[dict] = Field(default=None, description="Additional parameters passed to the API provider.")
 
 
 class BaseAgent:


### PR DESCRIPTION
**Problem**
Currently in Pyright when you define a pydantic model but fail to indicate a default as a kwarg then Pyright treats this as a mandatory argument. 

**Steps to reproduce**
- Create a v2 pydantic v2 model with arg defaults
- Attempt to create an instance of the model
- Check with Pyright

**Partial Solution**
Specify default in fields to remove Pyright error.  Have currently adjusted base_agent.py as this is where I am affected but unsure about the whole codebase (not looked).

**Future Solution**
Either wait for pyright to come around to supporting defaults as args or go through whole codebase and replace all pydantic models with default= kwarg.

**Related Sources**
https://github.com/pydantic/pydantic/discussions/7379
https://stackoverflow.com/questions/78672415/pydantic-model-field-with-default-value-does-not-pass-type-checking