### PR TITLE
Documentation/web search example improvements

### DIFF
--- a/atomic-examples/web-search-agent/README.md
+++ b/atomic-examples/web-search-agent/README.md
@@ -43,7 +43,9 @@ To run the Web Search Agent:
    OPENAI_API_KEY=your_openai_api_key
    SEARXNG_BASE_URL=your_searxng_instance_url
    ```
-   Replace `your_openai_api_key` with your actual OpenAI API key and `your_searxng_instance_url` with the URL of your SearxNG instance.
+   Replace `your_openai_api_key` with your actual OpenAI API key and `your_searxng_instance_url` with the URL of your SearxNG instance.  
+   If you do not have a SearxNG instance, see the instructions below to set up one locally with docker.
+
 
 5. Run the Web Search Agent:
    ```
@@ -57,6 +59,30 @@ To run the Web Search Agent:
 3. The SearxNG Search Tool performs web searches using the generated queries.
 4. The Question Answering Agent analyzes the search results and formulates a detailed answer.
 5. The main script presents the answer, along with references and follow-up questions.
+
+## SearxNG Setup with docker
+
+From the [official instructions](https://docs.searxng.org/admin/installation-docker.html):
+
+```shell
+mkdir my-instance
+cd my-instance
+export PORT=8080
+docker pull searxng/searxng
+docker run --rm \
+           -d -p ${PORT}:8080 \
+           -v "${PWD}/searxng:/etc/searxng" \
+           -e "BASE_URL=http://localhost:$PORT/" \
+           -e "INSTANCE_NAME=my-instance" \
+           searxng/searxng
+```
+
+Set the `SEARXNG_BASE_URL` environment variable to `http://localhost:8080/` in your `.env` file.
+
+
+Note: for the agent to communicate with SearxNG, the instance must enable the JSON engine, which is disabled by default.
+Edit `searxng/settings.yml` and add `- json` in the `search.formats` section, then restart the container.  
+
 
 ## Customization
 

--- a/atomic-examples/web-search-agent/web_search_agent/agents/query_agent.py
+++ b/atomic-examples/web-search-agent/web_search_agent/agents/query_agent.py
@@ -5,6 +5,9 @@ from atomic_agents.agents.base_agent import BaseIOSchema, BaseAgent, BaseAgentCo
 from atomic_agents.lib.components.system_prompt_generator import SystemPromptGenerator
 
 from web_search_agent.tools.searxng_search import SearxNGSearchTool
+import dotenv
+
+dotenv.load_dotenv()
 
 
 class QueryAgentInputSchema(BaseIOSchema):

--- a/atomic-examples/web-search-agent/web_search_agent/main.py
+++ b/atomic-examples/web-search-agent/web_search_agent/main.py
@@ -3,7 +3,6 @@ from dotenv import load_dotenv
 from rich.console import Console
 from rich.markdown import Markdown
 
-from atomic_agents.agents.base_agent import BaseAgent, BaseAgentConfig
 from atomic_agents.lib.components.agent_memory import AgentMemory
 from atomic_agents.lib.components.system_prompt_generator import SystemPromptContextProviderBase
 
@@ -16,8 +15,6 @@ from web_search_agent.tools.searxng_search import (
 from web_search_agent.agents.query_agent import QueryAgentInputSchema, query_agent
 from web_search_agent.agents.question_answering_agent import question_answering_agent, QuestionAnsweringAgentInputSchema
 
-import openai
-import instructor
 
 load_dotenv()
 
@@ -29,15 +26,6 @@ memory = AgentMemory()
 
 # Initialize the SearxNGSearchTool
 search_tool = SearxNGSearchTool(config=SearxNGSearchToolConfig(base_url=os.getenv("SEARXNG_BASE_URL"), max_results=5))
-
-# Initialize the BaseAgent
-agent = BaseAgent(
-    config=BaseAgentConfig(
-        client=instructor.from_openai(openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))),
-        model="gpt-4o-mini",
-        memory=memory,
-    )
-)
 
 # Example usage
 instruction = "Tell me about the Atomic Agents AI agent framework."


### PR DESCRIPTION
I was going through the web search example and found a few things to improve:
- The `agent` we define is not used, since we import `query_agent` --> removed it
- The `query_agent` is loaded before we call `dotenv.load_dotenv()` so API is not found --> added an extra `dotenv.load_dotenv()`
- The various searxNG public urls I tried did not work, I suspect they are blocking bots (keep getting HTTP 429), so I added instructions to spin up an instance with docker. Maybe this one belongs in the general documentation as I see we use the tool in many places?