### PR TITLE
feat: add Streamable HTTP support to MCPToolFactory

### DIFF
--- a/atomic-agents/atomic_agents/lib/factories/tool_definition_service.py
+++ b/atomic-agents/atomic_agents/lib/factories/tool_definition_service.py
@@ -9,6 +9,7 @@ from enum import Enum
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
 
 logger = logging.getLogger(__name__)
 
@@ -80,11 +81,12 @@ class ToolDefinitionService:
                 stdio_transport = await stack.enter_async_context(stdio_client(server_params))
                 read_stream, write_stream = stdio_transport
             elif self.transport_type == MCPTransportType.HTTP_STREAM:
-                # HTTP Stream transport
-                transport_endpoint = f"{self.endpoint}/mcp"
+                # HTTP Stream transport - use trailing slash to avoid redirect
+                # See: https://github.com/modelcontextprotocol/python-sdk/issues/732
+                transport_endpoint = f"{self.endpoint}/mcp/"
                 logger.info(f"Attempting HTTP Stream connection to {transport_endpoint}")
-                transport = await stack.enter_async_context(sse_client(transport_endpoint))
-                read_stream, write_stream = transport
+                transport = await stack.enter_async_context(streamablehttp_client(transport_endpoint))
+                read_stream, write_stream, _ = transport
             elif self.transport_type == MCPTransportType.SSE:
                 # SSE transport (deprecated)
                 transport_endpoint = f"{self.endpoint}/sse"

--- a/atomic-agents/atomic_agents/lib/factories/tool_definition_service.py
+++ b/atomic-agents/atomic_agents/lib/factories/tool_definition_service.py
@@ -23,17 +23,19 @@ class MCPToolDefinition(NamedTuple):
 class ToolDefinitionService:
     """Service for fetching tool definitions from MCP endpoints."""
 
-    def __init__(self, endpoint: Optional[str] = None, use_stdio: bool = False, working_directory: Optional[str] = None):
+    def __init__(self, endpoint: Optional[str] = None, use_stdio: bool = False, use_http_stream: bool = False, working_directory: Optional[str] = None):
         """
         Initialize the service.
 
         Args:
-            endpoint: URL of the MCP server (for SSE) or command string (for STDIO)
+            endpoint: URL of the MCP server (for SSE/HTTP stream) or command string (for STDIO)
             use_stdio: Whether to use STDIO transport
+            use_http_stream: Whether to use HTTP stream transport (no '/sse')
             working_directory: Optional working directory to use when running STDIO commands
         """
         self.endpoint = endpoint
         self.use_stdio = use_stdio
+        self.use_http_stream = use_http_stream
         self.working_directory = working_directory
 
     async def fetch_definitions(self) -> List[MCPToolDefinition]:
@@ -55,7 +57,7 @@ class ToolDefinitionService:
         stack = AsyncExitStack()
         try:
             if self.use_stdio:
-                # Split the command string into the command and its arguments
+                # STDIO transport
                 command_parts = shlex.split(self.endpoint)
                 if not command_parts:
                     raise ValueError("STDIO command string cannot be empty.")
@@ -65,11 +67,18 @@ class ToolDefinitionService:
                 server_params = StdioServerParameters(command=command, args=args, env=None, cwd=self.working_directory)
                 stdio_transport = await stack.enter_async_context(stdio_client(server_params))
                 read_stream, write_stream = stdio_transport
+            elif self.use_http_stream:
+                # HTTP Stream transport
+                transport_endpoint = f"{self.endpoint}/mcp"
+                logger.info(f"Attempting HTTP Stream connection to {transport_endpoint}")
+                transport = await stack.enter_async_context(sse_client(transport_endpoint))
+                read_stream, write_stream = transport
             else:
-                sse_endpoint = f"{self.endpoint}/sse"
-                logger.info(f"Attempting SSE connection to {sse_endpoint}")
-                sse_transport = await stack.enter_async_context(sse_client(sse_endpoint))
-                read_stream, write_stream = sse_transport
+                # Default to SSE transport (deprecated)
+                transport_endpoint = f"{self.endpoint}/sse"
+                logger.info(f"Attempting SSE connection to {transport_endpoint}")
+                transport = await stack.enter_async_context(sse_client(transport_endpoint))
+                read_stream, write_stream = transport
 
             session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
             definitions = await self.fetch_definitions_from_session(session)

--- a/atomic-agents/atomic_agents/lib/factories/tool_definition_service.py
+++ b/atomic-agents/atomic_agents/lib/factories/tool_definition_service.py
@@ -4,12 +4,21 @@ import logging
 import shlex
 from contextlib import AsyncExitStack
 from typing import List, NamedTuple, Optional, Dict, Any
+from enum import Enum
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 
 logger = logging.getLogger(__name__)
+
+
+class MCPTransportType(Enum):
+    """Enum for MCP transport types."""
+
+    SSE = "sse"
+    HTTP_STREAM = "http_stream"
+    STDIO = "stdio"
 
 
 class MCPToolDefinition(NamedTuple):
@@ -26,8 +35,7 @@ class ToolDefinitionService:
     def __init__(
         self,
         endpoint: Optional[str] = None,
-        use_stdio: bool = False,
-        use_http_stream: bool = False,
+        transport_type: MCPTransportType = MCPTransportType.HTTP_STREAM,
         working_directory: Optional[str] = None,
     ):
         """
@@ -35,13 +43,11 @@ class ToolDefinitionService:
 
         Args:
             endpoint: URL of the MCP server (for SSE/HTTP stream) or command string (for STDIO)
-            use_stdio: Whether to use STDIO transport
-            use_http_stream: Whether to use HTTP stream transport (no '/sse')
+            transport_type: Type of transport to use (SSE, HTTP_STREAM, or STDIO)
             working_directory: Optional working directory to use when running STDIO commands
         """
         self.endpoint = endpoint
-        self.use_stdio = use_stdio
-        self.use_http_stream = use_http_stream
+        self.transport_type = transport_type
         self.working_directory = working_directory
 
     async def fetch_definitions(self) -> List[MCPToolDefinition]:
@@ -62,7 +68,7 @@ class ToolDefinitionService:
         definitions = []
         stack = AsyncExitStack()
         try:
-            if self.use_stdio:
+            if self.transport_type == MCPTransportType.STDIO:
                 # STDIO transport
                 command_parts = shlex.split(self.endpoint)
                 if not command_parts:
@@ -73,18 +79,21 @@ class ToolDefinitionService:
                 server_params = StdioServerParameters(command=command, args=args, env=None, cwd=self.working_directory)
                 stdio_transport = await stack.enter_async_context(stdio_client(server_params))
                 read_stream, write_stream = stdio_transport
-            elif self.use_http_stream:
+            elif self.transport_type == MCPTransportType.HTTP_STREAM:
                 # HTTP Stream transport
                 transport_endpoint = f"{self.endpoint}/mcp"
                 logger.info(f"Attempting HTTP Stream connection to {transport_endpoint}")
                 transport = await stack.enter_async_context(sse_client(transport_endpoint))
                 read_stream, write_stream = transport
-            else:
-                # Default to SSE transport (deprecated)
+            elif self.transport_type == MCPTransportType.SSE:
+                # SSE transport (deprecated)
                 transport_endpoint = f"{self.endpoint}/sse"
                 logger.info(f"Attempting SSE connection to {transport_endpoint}")
                 transport = await stack.enter_async_context(sse_client(transport_endpoint))
                 read_stream, write_stream = transport
+            else:
+                available_types = [t.value for t in MCPTransportType]
+                raise ValueError(f"Unknown transport type: {self.transport_type}. Available types: {available_types}")
 
             session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
             definitions = await self.fetch_definitions_from_session(session)

--- a/atomic-agents/atomic_agents/lib/factories/tool_definition_service.py
+++ b/atomic-agents/atomic_agents/lib/factories/tool_definition_service.py
@@ -23,7 +23,13 @@ class MCPToolDefinition(NamedTuple):
 class ToolDefinitionService:
     """Service for fetching tool definitions from MCP endpoints."""
 
-    def __init__(self, endpoint: Optional[str] = None, use_stdio: bool = False, use_http_stream: bool = False, working_directory: Optional[str] = None):
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        use_stdio: bool = False,
+        use_http_stream: bool = False,
+        working_directory: Optional[str] = None,
+    ):
         """
         Initialize the service.
 

--- a/atomic-agents/tests/lib/factories/test_mcp_tool_factory.py
+++ b/atomic-agents/tests/lib/factories/test_mcp_tool_factory.py
@@ -414,19 +414,19 @@ def test_run_tool_with_persistent_session_no_event_loop(monkeypatch):
 def test_http_stream_connection_error_handling(monkeypatch):
     """Test HTTP stream connection error handling in MCPToolFactory."""
     from atomic_agents.lib.factories.tool_definition_service import ToolDefinitionService
-    
+
     # Mock ToolDefinitionService.fetch_definitions to raise ConnectionError for HTTP_STREAM
     original_fetch = ToolDefinitionService.fetch_definitions
-    
+
     async def mock_fetch_definitions(self):
         if self.transport_type == MCPTransportType.HTTP_STREAM:
             raise ConnectionError("HTTP stream connection failed")
         return await original_fetch(self)
-    
+
     monkeypatch.setattr(ToolDefinitionService, "fetch_definitions", mock_fetch_definitions)
-    
+
     factory = MCPToolFactory("http://test-endpoint", MCPTransportType.HTTP_STREAM)
-    
+
     with pytest.raises(ConnectionError, match="HTTP stream connection failed"):
         factory._fetch_tool_definitions()
 
@@ -434,6 +434,6 @@ def test_http_stream_connection_error_handling(monkeypatch):
 def test_http_stream_endpoint_formatting():
     """Test that HTTP stream endpoints are properly formatted with /mcp/ suffix."""
     factory = MCPToolFactory("http://test-endpoint", MCPTransportType.HTTP_STREAM)
-    
+
     # Verify the factory was created with correct transport type
     assert factory.transport_type == MCPTransportType.HTTP_STREAM

--- a/atomic-agents/tests/lib/factories/test_tool_definition_service.py
+++ b/atomic-agents/tests/lib/factories/test_tool_definition_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from atomic_agents.lib.factories.tool_definition_service import (
     ToolDefinitionService,
     MCPToolDefinition,
+    MCPTransportType,
 )
 
 
@@ -91,7 +92,7 @@ class TestToolDefinitionService:
     @pytest.mark.asyncio
     async def test_fetch_via_stdio(self):
         # Create service
-        service = ToolDefinitionService("command arg1 arg2", use_stdio=True)
+        service = ToolDefinitionService("command arg1 arg2", MCPTransportType.STDIO)
 
         # Mock the fetch_definitions_from_session method
         service.fetch_definitions_from_session = AsyncMock(
@@ -123,7 +124,7 @@ class TestToolDefinitionService:
     @pytest.mark.asyncio
     async def test_stdio_empty_command(self):
         # Create service with empty command
-        service = ToolDefinitionService("", use_stdio=True)
+        service = ToolDefinitionService("", MCPTransportType.STDIO)
 
         # Test that ValueError is raised for empty command
         with pytest.raises(ValueError, match="Endpoint is required"):
@@ -173,7 +174,7 @@ class TestToolDefinitionService:
 
     @pytest.mark.asyncio
     async def test_stdio_command_parts_empty(self):
-        svc = ToolDefinitionService("   ", use_stdio=True)
+        svc = ToolDefinitionService("   ", MCPTransportType.STDIO)
         with pytest.raises(
             RuntimeError, match="Unexpected error during tool definition fetching: STDIO command string cannot be empty"
         ):

--- a/atomic-examples/mcp-agent/README.md
+++ b/atomic-examples/mcp-agent/README.md
@@ -107,7 +107,7 @@ This example shows the flexibility of the MCP architecture with two distinct tra
 
    # Second terminal: Run the client with HTTP Stream transport
    cd example-client
-   poetry run python -m example_client.main --transport http
+   poetry run python -m example_client.main --transport http_stream
    ```
 
 ## Example Queries

--- a/atomic-examples/mcp-agent/README.md
+++ b/atomic-examples/mcp-agent/README.md
@@ -49,6 +49,12 @@ This example shows the flexibility of the MCP architecture with two distinct tra
 - Multiple clients can connect to one server
 - Better for production deployments
 
+### HTTP Stream Transport
+
+- The server exposes a single `/mcp` HTTP endpoint for session negotiation, JSON-RPC calls, and termination
+- Supports GET (stream/session ID), POST (JSON-RPC payloads), and DELETE (session cancel)
+- Useful for HTTP clients that prefer a single transport endpoint
+
 ## Getting Started
 
 1. Clone the repository:
@@ -64,9 +70,8 @@ This example shows the flexibility of the MCP architecture with two distinct tra
    cd example-mcp-server
    poetry install
    ```
-
+   
 3. Set up the client:
-
    ```bash
    cd ../example-client
    poetry install
@@ -80,7 +85,7 @@ This example shows the flexibility of the MCP architecture with two distinct tra
    cd example-client
    poetry run python -m example_client.main
    ```
-
+   
    **Using SSE transport:**
 
    ```bash
@@ -92,8 +97,18 @@ This example shows the flexibility of the MCP architecture with two distinct tra
    cd example-client
    poetry run python -m example_client.main --transport sse
    ```
+   
+   **Using HTTP Stream transport:**
 
-   **Note:** When using SSE transport, make sure the server is running before starting the client. The server runs on port 6969 by default.
+   ```bash
+   # First terminal: Start the server
+   cd example-mcp-server
+   poetry run python -m example_mcp_server.server_http
+
+   # Second terminal: Run the client with HTTP Stream transport
+   cd example-client
+   poetry run python -m example_client.main --transport http
+   ```
 
 ## Example Queries
 

--- a/atomic-examples/mcp-agent/README.md
+++ b/atomic-examples/mcp-agent/README.md
@@ -110,6 +110,8 @@ This example shows the flexibility of the MCP architecture with two distinct tra
    poetry run python -m example_client.main --transport http_stream
    ```
 
+**Note:** When using SSE or HTTP Stream transport, make sure the server is running before starting the client. The server runs on port 6969 by default.
+
 ## Example Queries
 
 The example includes a set of basic arithmetic tools that demonstrate the agent's capability to break down and solve complex mathematical expressions:

--- a/atomic-examples/mcp-agent/example-client/example_client/main.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main.py
@@ -26,9 +26,9 @@ def main():
 
     # Map transport values to their corresponding main functions
     transport_mapping = {
-        MCPTransportType.STDIO.value: ("example_client.main_stdio", "stdio_main"),
-        MCPTransportType.SSE.value: ("example_client.main_sse", "sse_main"),
-        MCPTransportType.HTTP_STREAM.value: ("example_client.main_http", "http_main"),
+        MCPTransportType.STDIO.value: ("example_client.main_stdio", "main"),
+        MCPTransportType.SSE.value: ("example_client.main_sse", "main"),
+        MCPTransportType.HTTP_STREAM.value: ("example_client.main_http", "main"),
     }
 
     if args.transport in transport_mapping:

--- a/atomic-examples/mcp-agent/example-client/example_client/main.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main.py
@@ -13,9 +13,9 @@ def main():
     parser = argparse.ArgumentParser(description="MCP Agent example client")
     parser.add_argument(
         "--transport",
-        choices=["stdio", "sse"],
+        choices=["stdio", "sse", "http"],
         default="stdio",
-        help="Transport method to use for MCP communication (stdio or sse)",
+        help="Transport method to use for MCP communication (stdio, sse, or http)",
     )
     args = parser.parse_args()
 
@@ -28,7 +28,7 @@ def main():
         except ImportError as e:
             print(f"Failed to import STDIO implementation: {e}")
             sys.exit(1)
-    else:
+    elif args.transport == "sse":
         # Import and run SSE implementation
         try:
             from example_client.main_sse import main as sse_main
@@ -37,6 +37,18 @@ def main():
         except ImportError as e:
             print(f"Failed to import SSE implementation: {e}")
             sys.exit(1)
+    elif args.transport == "http":
+        # Import and run HTTP implementation
+        try:
+            from example_client.main_http import main as http_main
+
+            http_main()
+        except ImportError as e:
+            print(f"Failed to import HTTP implementation: {e}")
+            sys.exit(1)
+    else:
+        print(f"Unknown transport: {args.transport}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/atomic-examples/mcp-agent/example-client/example_client/main.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main.py
@@ -6,48 +6,43 @@ This file serves as a launcher that can run either the STDIO or SSE transport ve
 
 import argparse
 import sys
+from atomic_agents.lib.factories.tool_definition_service import MCPTransportType
 
 
 def main():
     """Parse command line arguments and launch the appropriate implementation."""
     parser = argparse.ArgumentParser(description="MCP Agent example client")
+
+    # Get available transport choices from the enum
+    transport_choices = [transport.value for transport in MCPTransportType]
+
     parser.add_argument(
         "--transport",
-        choices=["stdio", "sse", "http"],
-        default="stdio",
-        help="Transport method to use for MCP communication (stdio, sse, or http)",
+        choices=transport_choices,
+        default=MCPTransportType.STDIO.value,
+        help=f"Transport method to use for MCP communication. Available: {', '.join(transport_choices)}",
     )
     args = parser.parse_args()
 
-    if args.transport == "stdio":
-        # Import and run STDIO implementation
-        try:
-            from example_client.main_stdio import main as stdio_main
+    # Map transport values to their corresponding main functions
+    transport_mapping = {
+        MCPTransportType.STDIO.value: ("example_client.main_stdio", "stdio_main"),
+        MCPTransportType.SSE.value: ("example_client.main_sse", "sse_main"),
+        MCPTransportType.HTTP_STREAM.value: ("example_client.main_http", "http_main"),
+    }
 
-            stdio_main()
-        except ImportError as e:
-            print(f"Failed to import STDIO implementation: {e}")
-            sys.exit(1)
-    elif args.transport == "sse":
-        # Import and run SSE implementation
+    if args.transport in transport_mapping:
+        module_name, function_name = transport_mapping[args.transport]
         try:
-            from example_client.main_sse import main as sse_main
-
-            sse_main()
+            module = __import__(module_name, fromlist=[function_name])
+            main_func = getattr(module, function_name)
+            main_func()
         except ImportError as e:
-            print(f"Failed to import SSE implementation: {e}")
-            sys.exit(1)
-    elif args.transport == "http":
-        # Import and run HTTP implementation
-        try:
-            from example_client.main_http import main as http_main
-
-            http_main()
-        except ImportError as e:
-            print(f"Failed to import HTTP implementation: {e}")
+            print(f"Failed to import {args.transport} implementation: {e}")
             sys.exit(1)
     else:
         print(f"Unknown transport: {args.transport}")
+        print(f"Available transports: {', '.join(transport_choices)}")
         sys.exit(1)
 
 

--- a/atomic-examples/mcp-agent/example-client/example_client/main_http.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_http.py
@@ -5,6 +5,7 @@ Communicates with the server_http.py `/mcp` endpoint using HTTP GET/POST/DELETE 
 
 import sys
 from atomic_agents.lib.factories.mcp_tool_factory import fetch_mcp_tools
+from atomic_agents.lib.factories.tool_definition_service import MCPTransportType
 from rich.console import Console
 from rich.table import Table
 from pydantic import Field
@@ -38,7 +39,7 @@ def main():
     client = instructor.from_openai(openai.OpenAI(api_key=config.openai_api_key))
 
     console.print("[bold green]Initializing MCP Agent System (HTTP Stream mode)...[/bold green]")
-    tools = fetch_mcp_tools(mcp_endpoint=config.mcp_server_url, use_stdio=False, use_http_stream=True)
+    tools = fetch_mcp_tools(mcp_endpoint=config.mcp_server_url, transport_type=MCPTransportType.HTTP_STREAM)
     if not tools:
         console.print(f"[bold red]No MCP tools found at {config.mcp_server_url}[/bold red]")
         sys.exit(1)

--- a/atomic-examples/mcp-agent/example-client/example_client/main_http.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_http.py
@@ -1,0 +1,159 @@
+"""
+HTTP Stream transport client for MCP Agent example.
+Communicates with the server_http.py `/mcp` endpoint using HTTP GET/POST/DELETE for JSON-RPC streams.
+"""
+import sys
+from atomic_agents.lib.factories.mcp_tool_factory import fetch_mcp_tools
+from rich.console import Console
+from rich.table import Table
+from rich.markdown import Markdown
+from pydantic import Field
+from atomic_agents.agents.base_agent import BaseIOSchema, BaseAgent, BaseAgentConfig
+from atomic_agents.lib.components.system_prompt_generator import SystemPromptGenerator
+from atomic_agents.lib.components.chat_history import ChatHistory
+import openai, os, instructor
+from typing import Union, Type, Dict
+from dataclasses import dataclass
+import re
+
+
+@dataclass
+class MCPConfig:
+    """Configuration for the MCP Agent system using HTTP Stream transport."""
+    mcp_server_url: str = "http://localhost:6969"
+    openai_model: str = "gpt-4o"
+    openai_api_key: str = os.getenv("OPENAI_API_KEY")
+
+    def __post_init__(self):
+        if not self.openai_api_key:
+            raise ValueError("OPENAI_API_KEY environment variable is not set")
+
+
+def main():
+    # Use default HTTP transport settings from MCPConfig
+    config = MCPConfig()
+    console = Console()
+    client = instructor.from_openai(openai.OpenAI(api_key=config.openai_api_key))
+
+    console.print("[bold green]Initializing MCP Agent System (HTTP Stream mode)...[/bold green]")
+    tools = fetch_mcp_tools(mcp_endpoint=config.mcp_server_url, use_stdio=False, use_http_stream=True)
+    if not tools:
+        console.print(f"[bold red]No MCP tools found at {config.mcp_server_url}[/bold red]")
+        sys.exit(1)
+
+    # Display available tools
+    table = Table(title="Available MCP Tools", box=None)
+    table.add_column("Tool Name", style="cyan")
+    table.add_column("Input Schema", style="yellow")
+    table.add_column("Description", style="magenta")
+    for ToolClass in tools:
+        schema_name = getattr(ToolClass.input_schema, '__name__', 'N/A')
+        table.add_row(ToolClass.mcp_tool_name, schema_name, ToolClass.__doc__ or "")
+    console.print(table)
+
+    # Build orchestrator
+    class MCPOrchestratorInputSchema(BaseIOSchema):
+        """Input schema for the MCP orchestrator that processes user queries."""
+        query: str = Field(...)
+
+    class FinalResponseSchema(BaseIOSchema):
+        """Schema for the final response to the user."""
+        response_text: str = Field(...)
+
+    # Map schemas and define ActionUnion
+    tool_schema_map: Dict[Type[BaseIOSchema], Type] = {
+        ToolClass.input_schema: ToolClass for ToolClass in tools if hasattr(ToolClass, 'input_schema')
+    }
+    available_schemas = tuple(tool_schema_map.keys()) + (FinalResponseSchema,)
+    ActionUnion = Union[available_schemas]
+
+    class OrchestratorOutputSchema(BaseIOSchema):
+        """Output schema for the MCP orchestrator containing reasoning and selected action."""
+        reasoning: str
+        action: ActionUnion
+
+    history = ChatHistory()
+    orchestrator = BaseAgent[
+        MCPOrchestratorInputSchema, OrchestratorOutputSchema
+    ](
+        BaseAgentConfig(
+            client=client,
+            model=config.openai_model,
+            history=history,
+            system_prompt_generator=SystemPromptGenerator(
+                background=['You are an MCP orchestrator via HTTP.'],
+                steps=['Decide and invoke tools over HTTP stream.'],
+                output_instructions=['Provide reasoning and a single action schema.'],
+            ),
+        )
+    )
+
+    console.print("[bold green]HTTP Stream client ready. Type 'exit' to quit.[/bold green]")
+    while True:
+        query = console.input("[bold yellow]You:[/bold yellow] ").strip()
+        if query.lower() in {'exit', 'quit'}:
+            break
+        if not query:
+            continue
+        
+        try:
+            # Initial run with user query
+            orchestrator_output = orchestrator.run(MCPOrchestratorInputSchema(query=query))
+            
+            # Handle the output similar to SSE version
+            if hasattr(orchestrator_output, "chat_message") and not hasattr(orchestrator_output, "action"):
+                # Convert BaseAgentOutputSchema to FinalResponseSchema
+                action_instance = FinalResponseSchema(response_text=orchestrator_output.chat_message)
+                reasoning = "Response generated directly from chat model"
+            elif hasattr(orchestrator_output, "action"):
+                action_instance = orchestrator_output.action
+                reasoning = orchestrator_output.reasoning if hasattr(orchestrator_output, "reasoning") else "No reasoning provided"
+            else:
+                console.print("[yellow]Warning: Unexpected response format. Unable to process.[/yellow]")
+                continue
+                
+            console.print(f"[cyan]Orchestrator reasoning:[/cyan] {reasoning}")
+            
+            # Keep executing until we get a final response
+            while not isinstance(action_instance, FinalResponseSchema):
+                # Find the matching tool class
+                tool_class = tool_schema_map.get(type(action_instance))
+                if not tool_class:
+                    console.print(f"[red]Error: No tool found for schema {type(action_instance)}[/red]")
+                    action_instance = FinalResponseSchema(response_text="I encountered an internal error. Could not find the appropriate tool.")
+                    break
+                
+                # Execute the tool
+                console.print(f"[blue]Executing {tool_class.mcp_tool_name}...[/blue]")
+                tool_instance = tool_class()
+                try:
+                    result = tool_instance.run(action_instance)
+                    console.print(f"[green]Tool result:[/green] {result}")
+                    
+                    # Ask orchestrator what to do next with the result
+                    next_query = f"Based on the tool result: {result}, please provide the final response to the user's original query: {query}"
+                    next_output = orchestrator.run(MCPOrchestratorInputSchema(query=next_query))
+                    
+                    if hasattr(next_output, "action"):
+                        action_instance = next_output.action
+                    else:
+                        # If no action, treat as final response
+                        action_instance = FinalResponseSchema(response_text=next_output.chat_message)
+                        
+                except Exception as e:
+                    console.print(f"[red]Error executing tool: {e}[/red]")
+                    action_instance = FinalResponseSchema(response_text=f"I encountered an error while executing the tool: {str(e)}")
+                    break
+            
+            # Display final response
+            if isinstance(action_instance, FinalResponseSchema):
+                console.print(f"[bold green]Assistant:[/bold green] {action_instance.response_text}")
+            else:
+                console.print("[red]Error: Expected final response but got something else[/red]")
+                
+        except Exception as e:
+            console.print(f"[red]Error: {e}[/red]")
+
+
+if __name__ == '__main__':
+    main()

--- a/atomic-examples/mcp-agent/example-client/example_client/main_http.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_http.py
@@ -2,24 +2,26 @@
 HTTP Stream transport client for MCP Agent example.
 Communicates with the server_http.py `/mcp` endpoint using HTTP GET/POST/DELETE for JSON-RPC streams.
 """
+
 import sys
 from atomic_agents.lib.factories.mcp_tool_factory import fetch_mcp_tools
 from rich.console import Console
 from rich.table import Table
-from rich.markdown import Markdown
 from pydantic import Field
 from atomic_agents.agents.base_agent import BaseIOSchema, BaseAgent, BaseAgentConfig
 from atomic_agents.lib.components.system_prompt_generator import SystemPromptGenerator
 from atomic_agents.lib.components.chat_history import ChatHistory
-import openai, os, instructor
+import openai
+import os
+import instructor
 from typing import Union, Type, Dict
 from dataclasses import dataclass
-import re
 
 
 @dataclass
 class MCPConfig:
     """Configuration for the MCP Agent system using HTTP Stream transport."""
+
     mcp_server_url: str = "http://localhost:6969"
     openai_model: str = "gpt-4o"
     openai_api_key: str = os.getenv("OPENAI_API_KEY")
@@ -47,43 +49,44 @@ def main():
     table.add_column("Input Schema", style="yellow")
     table.add_column("Description", style="magenta")
     for ToolClass in tools:
-        schema_name = getattr(ToolClass.input_schema, '__name__', 'N/A')
+        schema_name = getattr(ToolClass.input_schema, "__name__", "N/A")
         table.add_row(ToolClass.mcp_tool_name, schema_name, ToolClass.__doc__ or "")
     console.print(table)
 
     # Build orchestrator
     class MCPOrchestratorInputSchema(BaseIOSchema):
         """Input schema for the MCP orchestrator that processes user queries."""
+
         query: str = Field(...)
 
     class FinalResponseSchema(BaseIOSchema):
         """Schema for the final response to the user."""
+
         response_text: str = Field(...)
 
     # Map schemas and define ActionUnion
     tool_schema_map: Dict[Type[BaseIOSchema], Type] = {
-        ToolClass.input_schema: ToolClass for ToolClass in tools if hasattr(ToolClass, 'input_schema')
+        ToolClass.input_schema: ToolClass for ToolClass in tools if hasattr(ToolClass, "input_schema")
     }
     available_schemas = tuple(tool_schema_map.keys()) + (FinalResponseSchema,)
     ActionUnion = Union[available_schemas]
 
     class OrchestratorOutputSchema(BaseIOSchema):
         """Output schema for the MCP orchestrator containing reasoning and selected action."""
+
         reasoning: str
         action: ActionUnion
 
     history = ChatHistory()
-    orchestrator = BaseAgent[
-        MCPOrchestratorInputSchema, OrchestratorOutputSchema
-    ](
+    orchestrator = BaseAgent[MCPOrchestratorInputSchema, OrchestratorOutputSchema](
         BaseAgentConfig(
             client=client,
             model=config.openai_model,
             history=history,
             system_prompt_generator=SystemPromptGenerator(
-                background=['You are an MCP orchestrator via HTTP.'],
-                steps=['Decide and invoke tools over HTTP stream.'],
-                output_instructions=['Provide reasoning and a single action schema.'],
+                background=["You are an MCP orchestrator via HTTP."],
+                steps=["Decide and invoke tools over HTTP stream."],
+                output_instructions=["Provide reasoning and a single action schema."],
             ),
         )
     )
@@ -91,15 +94,15 @@ def main():
     console.print("[bold green]HTTP Stream client ready. Type 'exit' to quit.[/bold green]")
     while True:
         query = console.input("[bold yellow]You:[/bold yellow] ").strip()
-        if query.lower() in {'exit', 'quit'}:
+        if query.lower() in {"exit", "quit"}:
             break
         if not query:
             continue
-        
+
         try:
             # Initial run with user query
             orchestrator_output = orchestrator.run(MCPOrchestratorInputSchema(query=query))
-            
+
             # Handle the output similar to SSE version
             if hasattr(orchestrator_output, "chat_message") and not hasattr(orchestrator_output, "action"):
                 # Convert BaseAgentOutputSchema to FinalResponseSchema
@@ -107,53 +110,59 @@ def main():
                 reasoning = "Response generated directly from chat model"
             elif hasattr(orchestrator_output, "action"):
                 action_instance = orchestrator_output.action
-                reasoning = orchestrator_output.reasoning if hasattr(orchestrator_output, "reasoning") else "No reasoning provided"
+                reasoning = (
+                    orchestrator_output.reasoning if hasattr(orchestrator_output, "reasoning") else "No reasoning provided"
+                )
             else:
                 console.print("[yellow]Warning: Unexpected response format. Unable to process.[/yellow]")
                 continue
-                
+
             console.print(f"[cyan]Orchestrator reasoning:[/cyan] {reasoning}")
-            
+
             # Keep executing until we get a final response
             while not isinstance(action_instance, FinalResponseSchema):
                 # Find the matching tool class
                 tool_class = tool_schema_map.get(type(action_instance))
                 if not tool_class:
                     console.print(f"[red]Error: No tool found for schema {type(action_instance)}[/red]")
-                    action_instance = FinalResponseSchema(response_text="I encountered an internal error. Could not find the appropriate tool.")
+                    action_instance = FinalResponseSchema(
+                        response_text="I encountered an internal error. Could not find the appropriate tool."
+                    )
                     break
-                
+
                 # Execute the tool
                 console.print(f"[blue]Executing {tool_class.mcp_tool_name}...[/blue]")
                 tool_instance = tool_class()
                 try:
                     result = tool_instance.run(action_instance)
                     console.print(f"[green]Tool result:[/green] {result}")
-                    
+
                     # Ask orchestrator what to do next with the result
                     next_query = f"Based on the tool result: {result}, please provide the final response to the user's original query: {query}"
                     next_output = orchestrator.run(MCPOrchestratorInputSchema(query=next_query))
-                    
+
                     if hasattr(next_output, "action"):
                         action_instance = next_output.action
                     else:
                         # If no action, treat as final response
                         action_instance = FinalResponseSchema(response_text=next_output.chat_message)
-                        
+
                 except Exception as e:
                     console.print(f"[red]Error executing tool: {e}[/red]")
-                    action_instance = FinalResponseSchema(response_text=f"I encountered an error while executing the tool: {str(e)}")
+                    action_instance = FinalResponseSchema(
+                        response_text=f"I encountered an error while executing the tool: {str(e)}"
+                    )
                     break
-            
+
             # Display final response
             if isinstance(action_instance, FinalResponseSchema):
                 console.print(f"[bold green]Assistant:[/bold green] {action_instance.response_text}")
             else:
                 console.print("[red]Error: Expected final response but got something else[/red]")
-                
+
         except Exception as e:
             console.print(f"[red]Error: {e}[/red]")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/atomic-examples/mcp-agent/example-client/example_client/main_sse.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_sse.py
@@ -1,5 +1,6 @@
 # pyright: reportInvalidTypeForm=false
 from atomic_agents.lib.factories.mcp_tool_factory import fetch_mcp_tools
+from atomic_agents.lib.factories.tool_definition_service import MCPTransportType
 from rich.console import Console
 from rich.table import Table
 from rich.markdown import Markdown
@@ -48,7 +49,7 @@ class FinalResponseSchema(BaseIOSchema):
 # Fetch tools and build ActionUnion statically
 tools = fetch_mcp_tools(
     mcp_endpoint=config.mcp_server_url,
-    use_stdio=False,
+    transport_type=MCPTransportType.SSE,
 )
 if not tools:
     raise RuntimeError("No MCP tools found. Please ensure the MCP server is running and accessible.")

--- a/atomic-examples/mcp-agent/example-client/example_client/main_stdio.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_stdio.py
@@ -1,5 +1,6 @@
 # pyright: reportInvalidTypeForm=false
 from atomic_agents.lib.factories.mcp_tool_factory import fetch_mcp_tools
+from atomic_agents.lib.factories.tool_definition_service import MCPTransportType
 from rich.console import Console
 from rich.table import Table
 import openai
@@ -77,7 +78,7 @@ stdio_session = stdio_loop.run_until_complete(_bootstrap_stdio())
 # Fetch tools and build ActionUnion statically
 tools = fetch_mcp_tools(
     mcp_endpoint=None,
-    use_stdio=True,
+    transport_type=MCPTransportType.STDIO,
     client_session=stdio_session,  # Pass persistent session
     event_loop=stdio_loop,  # Pass corresponding loop
 )

--- a/atomic-examples/mcp-agent/example-client/poetry.lock
+++ b/atomic-examples/mcp-agent/example-client/poetry.lock
@@ -166,7 +166,7 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "atomic-agents"
-version = "1.1.0"
+version = "1.1.3"
 description = "A versatile framework for creating and managing intelligent agents."
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -178,7 +178,7 @@ develop = true
 gitpython = ">=3.1.43,<4.0.0"
 instructor = ">=1.3.4,<2.0.0"
 mcp = {version = "^1.6.0", extras = ["cli"]}
-pydantic = ">=2.10.3,<3.0.0"
+pydantic = ">=2.11.0,<3.0.0"
 pyfiglet = ">=1.0.2,<2.0.0"
 pyyaml = ">=6.0.2,<7.0.0"
 requests = ">=2.32.3,<3.0.0"
@@ -380,15 +380,16 @@ name = "example-mcp-server"
 version = "0.1.0"
 description = "example-mcp-server MCP server"
 optional = false
-python-versions = "*"
+python-versions = ">=3.12.0"
 groups = ["main"]
 files = []
 develop = true
 
 [package.dependencies]
-mcp = {version = "*", extras = ["cli"]}
+mcp = {version = ">=1.9.4", extras = ["cli"]}
 pydantic = ">=2.0.0"
 rich = ">=13.0.0"
+sse-starlette = ">=2.1.0"
 uvicorn = ">=0.15.0"
 
 [package.source]
@@ -894,14 +895,14 @@ files = [
 
 [[package]]
 name = "mcp"
-version = "1.6.0"
+version = "1.9.4"
 description = "Model Context Protocol SDK"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0"},
-    {file = "mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723"},
+    {file = "mcp-1.9.4-py3-none-any.whl", hash = "sha256:7fcf36b62936adb8e63f89346bccca1268eeca9bf6dfb562ee10b1dfbda9dac0"},
+    {file = "mcp-1.9.4.tar.gz", hash = "sha256:cfb0bcd1a9535b42edaef89947b9e18a8feb49362e1cc059d6e7fc636f2cb09f"},
 ]
 
 [package.dependencies]
@@ -911,10 +912,11 @@ httpx-sse = ">=0.4"
 pydantic = ">=2.7.2,<3.0.0"
 pydantic-settings = ">=2.5.2"
 python-dotenv = {version = ">=1.0.0", optional = true, markers = "extra == \"cli\""}
+python-multipart = ">=0.0.9"
 sse-starlette = ">=1.6.1"
 starlette = ">=0.27"
 typer = {version = ">=0.12.4", optional = true, markers = "extra == \"cli\""}
-uvicorn = ">=0.23.1"
+uvicorn = {version = ">=0.23.1", markers = "sys_platform != \"emscripten\""}
 
 [package.extras]
 cli = ["python-dotenv (>=1.0.0)", "typer (>=0.12.4)"]
@@ -1221,20 +1223,21 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.3"
+version = "2.11.7"
 description = "Data validation using Python type hints"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.10.3-py3-none-any.whl", hash = "sha256:be04d85bbc7b65651c5f8e6b9976ed9c6f41782a55524cef079a34a0bb82144d"},
-    {file = "pydantic-2.10.3.tar.gz", hash = "sha256:cb5ac360ce894ceacd69c403187900a02c4b20b693a9dd1d643e1effab9eadf9"},
+    {file = "pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b"},
+    {file = "pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
-pydantic-core = "2.27.1"
+pydantic-core = "2.33.2"
 typing-extensions = ">=4.12.2"
+typing-inspection = ">=0.4.0"
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
@@ -1242,112 +1245,111 @@ timezone = ["tzdata"]
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.1"
+version = "2.33.2"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic_core-2.27.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:71a5e35c75c021aaf400ac048dacc855f000bdfed91614b4a726f7432f1f3d6a"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f82d068a2d6ecfc6e054726080af69a6764a10015467d7d7b9f66d6ed5afa23b"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:121ceb0e822f79163dd4699e4c54f5ad38b157084d97b34de8b232bcaad70278"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4603137322c18eaf2e06a4495f426aa8d8388940f3c457e7548145011bb68e05"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a33cd6ad9017bbeaa9ed78a2e0752c5e250eafb9534f308e7a5f7849b0b1bfb4"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15cc53a3179ba0fcefe1e3ae50beb2784dede4003ad2dfd24f81bba4b23a454f"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45d9c5eb9273aa50999ad6adc6be5e0ecea7e09dbd0d31bd0c65a55a2592ca08"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8bf7b66ce12a2ac52d16f776b31d16d91033150266eb796967a7e4621707e4f6"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:655d7dd86f26cb15ce8a431036f66ce0318648f8853d709b4167786ec2fa4807"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:5556470f1a2157031e676f776c2bc20acd34c1990ca5f7e56f1ebf938b9ab57c"},
-    {file = "pydantic_core-2.27.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f69ed81ab24d5a3bd93861c8c4436f54afdf8e8cc421562b0c7504cf3be58206"},
-    {file = "pydantic_core-2.27.1-cp310-none-win32.whl", hash = "sha256:f5a823165e6d04ccea61a9f0576f345f8ce40ed533013580e087bd4d7442b52c"},
-    {file = "pydantic_core-2.27.1-cp310-none-win_amd64.whl", hash = "sha256:57866a76e0b3823e0b56692d1a0bf722bffb324839bb5b7226a7dbd6c9a40b17"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ac3b20653bdbe160febbea8aa6c079d3df19310d50ac314911ed8cc4eb7f8cb8"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a5a8e19d7c707c4cadb8c18f5f60c843052ae83c20fa7d44f41594c644a1d330"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f7059ca8d64fea7f238994c97d91f75965216bcbe5f695bb44f354893f11d52"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bed0f8a0eeea9fb72937ba118f9db0cb7e90773462af7962d382445f3005e5a4"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3cb37038123447cf0f3ea4c74751f6a9d7afef0eb71aa07bf5f652b5e6a132c"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:84286494f6c5d05243456e04223d5a9417d7f443c3b76065e75001beb26f88de"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acc07b2cfc5b835444b44a9956846b578d27beeacd4b52e45489e93276241025"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4fefee876e07a6e9aad7a8c8c9f85b0cdbe7df52b8a9552307b09050f7512c7e"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:258c57abf1188926c774a4c94dd29237e77eda19462e5bb901d88adcab6af919"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:35c14ac45fcfdf7167ca76cc80b2001205a8d5d16d80524e13508371fb8cdd9c"},
-    {file = "pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d1b26e1dff225c31897696cab7d4f0a315d4c0d9e8666dbffdb28216f3b17fdc"},
-    {file = "pydantic_core-2.27.1-cp311-none-win32.whl", hash = "sha256:2cdf7d86886bc6982354862204ae3b2f7f96f21a3eb0ba5ca0ac42c7b38598b9"},
-    {file = "pydantic_core-2.27.1-cp311-none-win_amd64.whl", hash = "sha256:3af385b0cee8df3746c3f406f38bcbfdc9041b5c2d5ce3e5fc6637256e60bbc5"},
-    {file = "pydantic_core-2.27.1-cp311-none-win_arm64.whl", hash = "sha256:81f2ec23ddc1b476ff96563f2e8d723830b06dceae348ce02914a37cb4e74b89"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9cbd94fc661d2bab2bc702cddd2d3370bbdcc4cd0f8f57488a81bcce90c7a54f"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5f8c4718cd44ec1580e180cb739713ecda2bdee1341084c1467802a417fe0f02"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15aae984e46de8d376df515f00450d1522077254ef6b7ce189b38ecee7c9677c"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1ba5e3963344ff25fc8c40da90f44b0afca8cfd89d12964feb79ac1411a260ac"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:992cea5f4f3b29d6b4f7f1726ed8ee46c8331c6b4eed6db5b40134c6fe1768bb"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0325336f348dbee6550d129b1627cb8f5351a9dc91aad141ffb96d4937bd9529"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7597c07fbd11515f654d6ece3d0e4e5093edc30a436c63142d9a4b8e22f19c35"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3bbd5d8cc692616d5ef6fbbbd50dbec142c7e6ad9beb66b78a96e9c16729b089"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:dc61505e73298a84a2f317255fcc72b710b72980f3a1f670447a21efc88f8381"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:e1f735dc43da318cad19b4173dd1ffce1d84aafd6c9b782b3abc04a0d5a6f5bb"},
-    {file = "pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f4e5658dbffe8843a0f12366a4c2d1c316dbe09bb4dfbdc9d2d9cd6031de8aae"},
-    {file = "pydantic_core-2.27.1-cp312-none-win32.whl", hash = "sha256:672ebbe820bb37988c4d136eca2652ee114992d5d41c7e4858cdd90ea94ffe5c"},
-    {file = "pydantic_core-2.27.1-cp312-none-win_amd64.whl", hash = "sha256:66ff044fd0bb1768688aecbe28b6190f6e799349221fb0de0e6f4048eca14c16"},
-    {file = "pydantic_core-2.27.1-cp312-none-win_arm64.whl", hash = "sha256:9a3b0793b1bbfd4146304e23d90045f2a9b5fd5823aa682665fbdaf2a6c28f3e"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f216dbce0e60e4d03e0c4353c7023b202d95cbaeff12e5fd2e82ea0a66905073"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a2e02889071850bbfd36b56fd6bc98945e23670773bc7a76657e90e6b6603c08"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42b0e23f119b2b456d07ca91b307ae167cc3f6c846a7b169fca5326e32fdc6cf"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:764be71193f87d460a03f1f7385a82e226639732214b402f9aa61f0d025f0737"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c00666a3bd2f84920a4e94434f5974d7bbc57e461318d6bb34ce9cdbbc1f6b2"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3ccaa88b24eebc0f849ce0a4d09e8a408ec5a94afff395eb69baf868f5183107"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c65af9088ac534313e1963443d0ec360bb2b9cba6c2909478d22c2e363d98a51"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:206b5cf6f0c513baffaeae7bd817717140770c74528f3e4c3e1cec7871ddd61a"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:062f60e512fc7fff8b8a9d680ff0ddaaef0193dba9fa83e679c0c5f5fbd018bc"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:a0697803ed7d4af5e4c1adf1670af078f8fcab7a86350e969f454daf598c4960"},
-    {file = "pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:58ca98a950171f3151c603aeea9303ef6c235f692fe555e883591103da709b23"},
-    {file = "pydantic_core-2.27.1-cp313-none-win32.whl", hash = "sha256:8065914ff79f7eab1599bd80406681f0ad08f8e47c880f17b416c9f8f7a26d05"},
-    {file = "pydantic_core-2.27.1-cp313-none-win_amd64.whl", hash = "sha256:ba630d5e3db74c79300d9a5bdaaf6200172b107f263c98a0539eeecb857b2337"},
-    {file = "pydantic_core-2.27.1-cp313-none-win_arm64.whl", hash = "sha256:45cf8588c066860b623cd11c4ba687f8d7175d5f7ef65f7129df8a394c502de5"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:5897bec80a09b4084aee23f9b73a9477a46c3304ad1d2d07acca19723fb1de62"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:d0165ab2914379bd56908c02294ed8405c252250668ebcb438a55494c69f44ab"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b9af86e1d8e4cfc82c2022bfaa6f459381a50b94a29e95dcdda8442d6d83864"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f6c8a66741c5f5447e047ab0ba7a1c61d1e95580d64bce852e3df1f895c4067"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a42d6a8156ff78981f8aa56eb6394114e0dedb217cf8b729f438f643608cbcd"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:64c65f40b4cd8b0e049a8edde07e38b476da7e3aaebe63287c899d2cff253fa5"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdcf339322a3fae5cbd504edcefddd5a50d9ee00d968696846f089b4432cf78"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bf99c8404f008750c846cb4ac4667b798a9f7de673ff719d705d9b2d6de49c5f"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8f1edcea27918d748c7e5e4d917297b2a0ab80cad10f86631e488b7cddf76a36"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-musllinux_1_1_armv7l.whl", hash = "sha256:159cac0a3d096f79ab6a44d77a961917219707e2a130739c64d4dd46281f5c2a"},
-    {file = "pydantic_core-2.27.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:029d9757eb621cc6e1848fa0b0310310de7301057f623985698ed7ebb014391b"},
-    {file = "pydantic_core-2.27.1-cp38-none-win32.whl", hash = "sha256:a28af0695a45f7060e6f9b7092558a928a28553366519f64083c63a44f70e618"},
-    {file = "pydantic_core-2.27.1-cp38-none-win_amd64.whl", hash = "sha256:2d4567c850905d5eaaed2f7a404e61012a51caf288292e016360aa2b96ff38d4"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:e9386266798d64eeb19dd3677051f5705bf873e98e15897ddb7d76f477131967"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4228b5b646caa73f119b1ae756216b59cc6e2267201c27d3912b592c5e323b60"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b3dfe500de26c52abe0477dde16192ac39c98f05bf2d80e76102d394bd13854"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aee66be87825cdf72ac64cb03ad4c15ffef4143dbf5c113f64a5ff4f81477bf9"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b748c44bb9f53031c8cbc99a8a061bc181c1000c60a30f55393b6e9c45cc5bd"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ca038c7f6a0afd0b2448941b6ef9d5e1949e999f9e5517692eb6da58e9d44be"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e0bd57539da59a3e4671b90a502da9a28c72322a4f17866ba3ac63a82c4498e"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ac6c2c45c847bbf8f91930d88716a0fb924b51e0c6dad329b793d670ec5db792"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b94d4ba43739bbe8b0ce4262bcc3b7b9f31459ad120fb595627eaeb7f9b9ca01"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:00e6424f4b26fe82d44577b4c842d7df97c20be6439e8e685d0d715feceb9fb9"},
-    {file = "pydantic_core-2.27.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:38de0a70160dd97540335b7ad3a74571b24f1dc3ed33f815f0880682e6880131"},
-    {file = "pydantic_core-2.27.1-cp39-none-win32.whl", hash = "sha256:7ccebf51efc61634f6c2344da73e366c75e735960b5654b63d7e6f69a5885fa3"},
-    {file = "pydantic_core-2.27.1-cp39-none-win_amd64.whl", hash = "sha256:a57847b090d7892f123726202b7daa20df6694cbd583b67a592e856bff603d6c"},
-    {file = "pydantic_core-2.27.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3fa80ac2bd5856580e242dbc202db873c60a01b20309c8319b5c5986fbe53ce6"},
-    {file = "pydantic_core-2.27.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d950caa237bb1954f1b8c9227b5065ba6875ac9771bb8ec790d956a699b78676"},
-    {file = "pydantic_core-2.27.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e4216e64d203e39c62df627aa882f02a2438d18a5f21d7f721621f7a5d3611d"},
-    {file = "pydantic_core-2.27.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02a3d637bd387c41d46b002f0e49c52642281edacd2740e5a42f7017feea3f2c"},
-    {file = "pydantic_core-2.27.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:161c27ccce13b6b0c8689418da3885d3220ed2eae2ea5e9b2f7f3d48f1d52c27"},
-    {file = "pydantic_core-2.27.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:19910754e4cc9c63bc1c7f6d73aa1cfee82f42007e407c0f413695c2f7ed777f"},
-    {file = "pydantic_core-2.27.1-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:e173486019cc283dc9778315fa29a363579372fe67045e971e89b6365cc035ed"},
-    {file = "pydantic_core-2.27.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:af52d26579b308921b73b956153066481f064875140ccd1dfd4e77db89dbb12f"},
-    {file = "pydantic_core-2.27.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:981fb88516bd1ae8b0cbbd2034678a39dedc98752f264ac9bc5839d3923fa04c"},
-    {file = "pydantic_core-2.27.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5fde892e6c697ce3e30c61b239330fc5d569a71fefd4eb6512fc6caec9dd9e2f"},
-    {file = "pydantic_core-2.27.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:816f5aa087094099fff7edabb5e01cc370eb21aa1a1d44fe2d2aefdfb5599b31"},
-    {file = "pydantic_core-2.27.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c10c309e18e443ddb108f0ef64e8729363adbfd92d6d57beec680f6261556f3"},
-    {file = "pydantic_core-2.27.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98476c98b02c8e9b2eec76ac4156fd006628b1b2d0ef27e548ffa978393fd154"},
-    {file = "pydantic_core-2.27.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3027001c28434e7ca5a6e1e527487051136aa81803ac812be51802150d880dd"},
-    {file = "pydantic_core-2.27.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:7699b1df36a48169cdebda7ab5a2bac265204003f153b4bd17276153d997670a"},
-    {file = "pydantic_core-2.27.1-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:1c39b07d90be6b48968ddc8c19e7585052088fd7ec8d568bb31ff64c70ae3c97"},
-    {file = "pydantic_core-2.27.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:46ccfe3032b3915586e469d4972973f893c0a2bb65669194a5bdea9bacc088c2"},
-    {file = "pydantic_core-2.27.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:62ba45e21cf6571d7f716d903b5b7b6d2617e2d5d67c0923dc47b9d41369f840"},
-    {file = "pydantic_core-2.27.1.tar.gz", hash = "sha256:62a763352879b84aa31058fc931884055fd75089cccbd9d58bb6afd01141b235"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e5b2671f05ba48b94cb90ce55d8bdcaaedb8ba00cc5359f6810fc918713983d"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0069c9acc3f3981b9ff4cdfaf088e98d83440a4c7ea1bc07460af3d4dc22e72d"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d53b22f2032c42eaaf025f7c40c2e3b94568ae077a606f006d206a463bc69572"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0405262705a123b7ce9f0b92f123334d67b70fd1f20a9372b907ce1080c7ba02"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b25d91e288e2c4e0662b8038a28c6a07eaac3e196cfc4ff69de4ea3db992a1b"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bdfe4b3789761f3bcb4b1ddf33355a71079858958e3a552f16d5af19768fef2"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:efec8db3266b76ef9607c2c4c419bdb06bf335ae433b80816089ea7585816f6a"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:031c57d67ca86902726e0fae2214ce6770bbe2f710dc33063187a68744a5ecac"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:f8de619080e944347f5f20de29a975c2d815d9ddd8be9b9b7268e2e3ef68605a"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:73662edf539e72a9440129f231ed3757faab89630d291b784ca99237fb94db2b"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-win32.whl", hash = "sha256:0a39979dcbb70998b0e505fb1556a1d550a0781463ce84ebf915ba293ccb7e22"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-win_amd64.whl", hash = "sha256:b0379a2b24882fef529ec3b4987cb5d003b9cda32256024e6fe1586ac45fc640"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9"},
+    {file = "pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac"},
+    {file = "pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5"},
+    {file = "pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a2b911a5b90e0374d03813674bf0a5fbbb7741570dcd4b4e85a2e48d17def29d"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6fa6dfc3e4d1f734a34710f391ae822e0a8eb8559a85c6979e14e65ee6ba2954"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c54c939ee22dc8e2d545da79fc5381f1c020d6d3141d3bd747eab59164dc89fb"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53a57d2ed685940a504248187d5685e49eb5eef0f696853647bf37c418c538f7"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09fb9dd6571aacd023fe6aaca316bd01cf60ab27240d7eb39ebd66a3a15293b4"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e6116757f7959a712db11f3e9c0a99ade00a5bbedae83cb801985aa154f071b"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d55ab81c57b8ff8548c3e4947f119551253f4e3787a7bbc0b6b3ca47498a9d3"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c20c462aa4434b33a2661701b861604913f912254e441ab8d78d30485736115a"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:44857c3227d3fb5e753d5fe4a3420d6376fa594b07b621e220cd93703fe21782"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:eb9b459ca4df0e5c87deb59d37377461a538852765293f9e6ee834f0435a93b9"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9fcd347d2cc5c23b06de6d3b7b8275be558a0c90549495c699e379a80bf8379e"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-win32.whl", hash = "sha256:83aa99b1285bc8f038941ddf598501a86f1536789740991d7d8756e34f1e74d9"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-win_amd64.whl", hash = "sha256:f481959862f57f29601ccced557cc2e817bce7533ab8e01a797a48b49c9692b3"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c4aa4e82353f65e548c476b37e64189783aa5384903bfea4f41580f255fddfa"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d946c8bf0d5c24bf4fe333af284c59a19358aa3ec18cb3dc4370080da1e8ad29"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b31b6846e361ef83fedb187bb5b4372d0da3f7e28d85415efa92d6125d6e6d"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa9d91b338f2df0508606f7009fde642391425189bba6d8c653afd80fd6bb64e"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2058a32994f1fde4ca0480ab9d1e75a0e8c87c22b53a3ae66554f9af78f2fe8c"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:0e03262ab796d986f978f79c943fc5f620381be7287148b8010b4097f79a39ec"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:1a8695a8d00c73e50bff9dfda4d540b7dee29ff9b8053e38380426a85ef10052"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fa754d1850735a0b0e03bcffd9d4b4343eb417e47196e4485d9cca326073a42c"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a11c8d26a50bfab49002947d3d237abe4d9e4b5bdc8846a63537b6488e197808"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:87acbfcf8e90ca885206e98359d7dca4bcbb35abdc0ff66672a293e1d7a19101"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f92c15cd1e97d4b12acd1cc9004fa092578acfa57b67ad5e43a197175d01a64"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f26877a748dc4251cfcfda9dfb5f13fcb034f5308388066bcfe9031b63ae7d"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac89aea9af8cd672fa7b510e7b8c33b0bba9a43186680550ccf23020f32d535"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:970919794d126ba8645f3837ab6046fb4e72bbc057b3709144066204c19a455d"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3eb3fe62804e8f859c49ed20a8451342de53ed764150cb14ca71357c765dc2a6"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:3abcd9392a36025e3bd55f9bd38d908bd17962cc49bc6da8e7e96285336e2bca"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:3a1c81334778f9e3af2f8aeb7a960736e5cab1dfebfb26aabca09afd2906c039"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2807668ba86cb38c6817ad9bc66215ab8584d1d304030ce4f0887336f28a5e27"},
+    {file = "pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc"},
 ]
 
 [package.dependencies]
@@ -1418,6 +1420,18 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
+    {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
+]
 
 [[package]]
 name = "pyyaml"
@@ -1875,4 +1889,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "1764fb4d5e9a19e1380e2d8a19e0bc04f8b8305a01394189fbd1c9f04b361a84"
+content-hash = "93a54c0a2c5c002db1a1036420d9670c2244f351ef3bb17b668e02463d0150a4"

--- a/atomic-examples/mcp-agent/example-client/pyproject.toml
+++ b/atomic-examples/mcp-agent/example-client/pyproject.toml
@@ -11,7 +11,7 @@ example-mcp-server = { path = "../example-mcp-server", develop = true }
 pydantic = ">=2.10.3,<3.0.0"
 rich = ">=13.0.0"
 openai = ">=1.0.0"
-mcp = {extras = ["cli"], version = "^1.6.0"}
+mcp = {extras = ["cli"], version = "^1.9.4"}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/atomic-examples/mcp-agent/example-mcp-server/README.md
+++ b/atomic-examples/mcp-agent/example-mcp-server/README.md
@@ -65,13 +65,13 @@ poetry run example-mcp-server --mode=sse --host 127.0.0.1 --port 8000
 poetry run example-mcp-server --mode=sse --reload
 
 # Run in HTTP Stream mode (default http://0.0.0.0:6969/mcp)
-poetry run example-mcp-server --mode=http
+poetry run example-mcp-server --mode=http_stream
 
 # Run in HTTP Stream mode with custom host/port
-poetry run example-mcp-server --mode=http --host 127.0.0.1 --port 8000
+poetry run example-mcp-server --mode=http_stream --host 127.0.0.1 --port 8000
 
 # Run in HTTP Stream mode with auto-reload
-poetry run example-mcp-server --mode=http --reload
+poetry run example-mcp-server --mode=http_stream --reload
 ```
 
 ### Using Python Module
@@ -82,7 +82,7 @@ Alternatively, you can run the server as a Python module:
 # Using the unified server script
 poetry run python -m example_mcp_server.server --mode=stdio
 poetry run python -m example_mcp_server.server --mode=sse
-poetry run python -m example_mcp_server.server --mode=http
+poetry run python -m example_mcp_server.server --mode=http_stream
 
 # Or call the specific implementations directly
 poetry run python -m example_mcp_server.server_stdio

--- a/atomic-examples/mcp-agent/example-mcp-server/README.md
+++ b/atomic-examples/mcp-agent/example-mcp-server/README.md
@@ -11,6 +11,7 @@ This project is an MCP (Model Context Protocol) server that provides tools and r
 │   ├── server.py                # Unified server entry point with mode selection
 │   ├── server_stdio.py          # Implementation for stdio transport
 │   ├── server_sse.py            # Implementation for SSE transport (HTTP)
+│   ├── server_http.py           # Implementation for HTTP Stream transport
 │   ├── interfaces/              # Base classes/interfaces for tools and resources
 │   │   ├── __init__.py
 │   │   ├── resource.py
@@ -44,7 +45,7 @@ This project is an MCP (Model Context Protocol) server that provides tools and r
 
 ## Running the Server
 
-The server can run in two modes: `stdio` (standard input/output) or `sse` (HTTP Server-Sent Events). You must specify the desired mode using the `--mode` parameter.
+The server can run in three modes: `stdio` (standard input/output), `sse` (HTTP Server-Sent Events), or `http` (HTTP Stream Transport). You must specify the desired mode using the `--mode` parameter.
 
 ### Using the Command Line Script
 
@@ -62,6 +63,15 @@ poetry run example-mcp-server --mode=sse --host 127.0.0.1 --port 8000
 
 # Run in SSE mode with auto-reload for development
 poetry run example-mcp-server --mode=sse --reload
+
+# Run in HTTP Stream mode (default http://0.0.0.0:6969/mcp)
+poetry run example-mcp-server --mode=http
+
+# Run in HTTP Stream mode with custom host/port
+poetry run example-mcp-server --mode=http --host 127.0.0.1 --port 8000
+
+# Run in HTTP Stream mode with auto-reload
+poetry run example-mcp-server --mode=http --reload
 ```
 
 ### Using Python Module
@@ -72,10 +82,12 @@ Alternatively, you can run the server as a Python module:
 # Using the unified server script
 poetry run python -m example_mcp_server.server --mode=stdio
 poetry run python -m example_mcp_server.server --mode=sse
+poetry run python -m example_mcp_server.server --mode=http
 
 # Or call the specific implementations directly
 poetry run python -m example_mcp_server.server_stdio
 poetry run python -m example_mcp_server.server_sse
+poetry run python -m example_mcp_server.server_http
 ```
 
 ## Client Integration
@@ -84,6 +96,7 @@ This server is designed to work with the companion MCP client in the `example-cl
 
 1. **STDIO Transport**: The client launches this server as a subprocess and communicates through standard input/output
 2. **SSE Transport**: The client connects to this server running as an HTTP service
+3. **HTTP Stream Transport**: The client connects to the `/mcp` endpoint for a streaming RPC-like interface
 
 ### STDIO Mode Connection
 
@@ -104,6 +117,16 @@ mcp_server_url: str = "http://localhost:6969"
 ```
 
 This mode is better for production deployments, sharing tools across multiple clients, or when the server needs to run on a different machine.
+
+### HTTP Stream Mode Connection
+
+In HTTP Stream mode, the client connects to the server's `/mcp` endpoint:
+
+```python
+mcp_server_url: str = "http://localhost:6969/mcp"
+```
+
+This mode supports a streaming RPC-like interaction over HTTP, where the client can negotiate a session, send JSON-RPC calls, and terminate the session.
 
 ## Developing Your Server
 

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server.py
@@ -11,14 +11,14 @@ def main():
         "--mode",
         type=str,
         required=True,
-        choices=["stdio", "sse", "http"],
-        help="Server mode: stdio for standard I/O, sse for Server-Sent Events, or http for HTTP Stream Transport",
+        choices=["stdio", "sse", "http_stream"],
+        help="Server mode: stdio for standard I/O, sse for Server-Sent Events, or http_stream for HTTP Stream Transport",
     )
 
-    # SSE specific arguments
-    parser.add_argument("--host", default="0.0.0.0", help="Host to bind to (SSE mode only)")
-    parser.add_argument("--port", type=int, default=6969, help="Port to listen on (SSE mode only)")
-    parser.add_argument("--reload", action="store_true", help="Enable auto-reload for development (SSE mode only)")
+    # HTTP Stream specific arguments
+    parser.add_argument("--host", default="0.0.0.0", help="Host to bind to (sse/http_stream mode only)")
+    parser.add_argument("--port", type=int, default=6969, help="Port to listen on (sse/http_stream mode only)")
+    parser.add_argument("--reload", action="store_true", help="Enable auto-reload for development (sse/http_stream mode only)")
 
     args = parser.parse_args()
 
@@ -35,7 +35,7 @@ def main():
         if args.reload:
             sys.argv.append("--reload")
         sse_main()
-    elif args.mode == "http":
+    elif args.mode == "http_stream":
         # Import and run the HTTP Stream Transport server
         from example_mcp_server.server_http import main as http_main
 

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server.py
@@ -11,8 +11,8 @@ def main():
         "--mode",
         type=str,
         required=True,
-        choices=["stdio", "sse"],
-        help="Server mode: stdio for standard I/O or sse for HTTP Server-Sent Events",
+        choices=["stdio", "sse", "http"],
+        help="Server mode: stdio for standard I/O, sse for Server-Sent Events, or http for HTTP Stream Transport",
     )
 
     # SSE specific arguments
@@ -35,6 +35,14 @@ def main():
         if args.reload:
             sys.argv.append("--reload")
         sse_main()
+    elif args.mode == "http":
+        # Import and run the HTTP Stream Transport server
+        from example_mcp_server.server_http import main as http_main
+
+        sys.argv = [sys.argv[0], "--host", args.host, "--port", str(args.port)]
+        if args.reload:
+            sys.argv.append("--reload")
+        http_main()
     else:
         parser.print_help()
         sys.exit(1)

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
@@ -1,22 +1,23 @@
 """example-mcp-server MCP Server HTTP Stream Transport."""
 
-from mcp.server.fastmcp import FastMCP
-from starlette.applications import Starlette
-from starlette.routing import Route, Mount
-from starlette.requests import Request
-from starlette.responses import JSONResponse
-from starlette.middleware import Middleware
-from starlette.middleware.cors import CORSMiddleware
-from mcp.server import Server
-from mcp.server.sse import SseServerTransport
-import uvicorn
 from typing import List
+import argparse
+
+import uvicorn
+from starlette.middleware.cors import CORSMiddleware
+
+from mcp.server.fastmcp import FastMCP
 
 from example_mcp_server.services.tool_service import ToolService
 from example_mcp_server.services.resource_service import ResourceService
 from example_mcp_server.interfaces.tool import Tool
 from example_mcp_server.interfaces.resource import Resource
-from example_mcp_server.tools import AddNumbersTool, SubtractNumbersTool, MultiplyNumbersTool, DivideNumbersTool
+from example_mcp_server.tools import (
+    AddNumbersTool,
+    SubtractNumbersTool,
+    MultiplyNumbersTool,
+    DivideNumbersTool,
+)
 
 
 def get_available_tools() -> List[Tool]:
@@ -34,92 +35,59 @@ def get_available_resources() -> List[Resource]:
     return []
 
 
-def create_http_app(mcp_server: Server) -> Starlette:
-    """Create a Starlette app supporting HTTP Stream Transport."""
+def create_mcp_server() -> FastMCP:
+    """Create and configure the MCP server."""
+    mcp = FastMCP("example-mcp-server")
+    tool_service = ToolService()
+    resource_service = ResourceService()
 
-    # Create SSE transport for handling the connection
-    sse = SseServerTransport("/messages/")
+    # Register all tools and their MCP handlers
+    tool_service.register_tools(get_available_tools())
+    tool_service.register_mcp_handlers(mcp)
 
-    async def handle_mcp(request: Request):
-        """Handle MCP requests over HTTP Stream - accepts GET for connection."""
-        try:
-            # Use SSE transport pattern for HTTP stream
-            async with sse.connect_sse(
-                request.scope,
-                request.receive,
-                request._send,
-            ) as (read_stream, write_stream):
-                await mcp_server.run(
-                    read_stream,
-                    write_stream,
-                    mcp_server.create_initialization_options(),
-                )
+    # Register all resources and their MCP handlers
+    resource_service.register_resources(get_available_resources())
+    resource_service.register_mcp_handlers(mcp)
 
-        except Exception as e:
-            error_response = {"jsonrpc": "2.0", "id": None, "error": {"code": -32603, "message": f"Internal error: {str(e)}"}}
-            return JSONResponse(error_response, status_code=500)
+    return mcp
 
-    middleware = [
-        Middleware(
-            CORSMiddleware,
-            allow_origins=["*"],
-            allow_methods=["*"],
-            allow_headers=["*"],
-            allow_credentials=True,
-        )
-    ]
 
-    return Starlette(
-        routes=[
-            Route("/mcp", handle_mcp, methods=["GET", "POST"]),
-            Mount("/messages/", app=sse.handle_post_message),
-        ],
-        middleware=middleware,
+def create_http_app():
+    """Create a FastMCP HTTP app with CORS middleware."""
+    mcp_server = create_mcp_server()
+
+    # Use FastMCP directly as the app instead of mounting it
+    # This avoids the task group initialization issue
+    # See: https://github.com/modelcontextprotocol/python-sdk/issues/732
+    app = mcp_server.streamable_http_app()  # type: ignore[attr-defined]
+    
+    # Apply CORS middleware manually
+    app = CORSMiddleware(
+        app,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+        allow_credentials=True,
     )
-
-
-# Initialize FastMCP server with HTTP transport - same as SSE
-mcp = FastMCP("example-mcp-server")
-tool_service = ToolService()
-resource_service = ResourceService()
-
-# Register all tools and their MCP handlers - same as SSE
-tool_service.register_tools(get_available_tools())
-tool_service.register_mcp_handlers(mcp)
-
-# Register all resources and their MCP handlers - same as SSE
-resource_service.register_resources(get_available_resources())
-resource_service.register_mcp_handlers(mcp)
-
-# Get the MCP server - same as SSE
-mcp_server = mcp._mcp_server  # noqa: WPS437
-
-# Create the Starlette app
-app = create_http_app(mcp_server)
-
-# Export the app
-__all__ = ["app"]
+    
+    return app
 
 
 def main():
     """Entry point for the HTTP Stream Transport server."""
-    import argparse
-
     parser = argparse.ArgumentParser(description="Run MCP HTTP Stream server")
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
     parser.add_argument("--port", type=int, default=6969, help="Port to listen on")
     parser.add_argument("--reload", action="store_true", help="Enable auto-reload for development")
     args = parser.parse_args()
 
+    app = create_http_app()
     print(f"MCP HTTP Stream Server starting on {args.host}:{args.port}")
-
     uvicorn.run(
-        "example_mcp_server.server_http:app",
+        app,
         host=args.host,
         port=args.port,
         reload=args.reload,
-        reload_dirs=["example_mcp_server"],
-        timeout_graceful_shutdown=5,
     )
 
 

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
@@ -60,7 +60,7 @@ def create_http_app():
     # This avoids the task group initialization issue
     # See: https://github.com/modelcontextprotocol/python-sdk/issues/732
     app = mcp_server.streamable_http_app()  # type: ignore[attr-defined]
-    
+
     # Apply CORS middleware manually
     app = CORSMiddleware(
         app,
@@ -69,7 +69,7 @@ def create_http_app():
         allow_headers=["*"],
         allow_credentials=True,
     )
-    
+
     return app
 
 

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
@@ -1,0 +1,141 @@
+"""example-mcp-server MCP Server HTTP Stream Transport."""
+
+from mcp.server.fastmcp import FastMCP
+from starlette.applications import Starlette
+from starlette.routing import Route, Mount
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+from mcp.server import Server
+from mcp.server.sse import SseServerTransport
+import uvicorn
+from typing import List
+import json
+
+from example_mcp_server.services.tool_service import ToolService
+from example_mcp_server.services.resource_service import ResourceService
+from example_mcp_server.interfaces.tool import Tool
+from example_mcp_server.interfaces.resource import Resource
+from example_mcp_server.tools import AddNumbersTool, SubtractNumbersTool, MultiplyNumbersTool, DivideNumbersTool
+
+
+def get_available_tools() -> List[Tool]:
+    """Get list of all available tools."""
+    return [
+        AddNumbersTool(),
+        SubtractNumbersTool(),
+        MultiplyNumbersTool(),
+        DivideNumbersTool(),
+    ]
+
+
+def get_available_resources() -> List[Resource]:
+    """Get list of all available resources."""
+    return []
+
+
+def create_http_app(mcp_server: Server) -> Starlette:
+    """Create a Starlette app supporting HTTP Stream Transport."""
+    
+    # Create SSE transport for handling the connection
+    sse = SseServerTransport("/messages/")
+    
+    async def handle_mcp(request: Request):
+        """Handle MCP requests over HTTP Stream - accepts GET for connection."""
+        try:
+            # Use SSE transport pattern for HTTP stream
+            async with sse.connect_sse(
+                request.scope,
+                request.receive,
+                request._send,
+            ) as (read_stream, write_stream):
+                await mcp_server.run(
+                    read_stream,
+                    write_stream,
+                    mcp_server.create_initialization_options(),
+                )
+                
+        except Exception as e:
+            error_response = {
+                "jsonrpc": "2.0", 
+                "id": None,
+                "error": {
+                    "code": -32603,
+                    "message": f"Internal error: {str(e)}"
+                }
+            }
+            return JSONResponse(error_response, status_code=500)
+
+    middleware = [
+        Middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+            allow_credentials=True,
+        )
+    ]
+
+    return Starlette(
+        routes=[
+            Route("/mcp", handle_mcp, methods=["GET", "POST"]),
+            Mount("/messages/", app=sse.handle_post_message),
+        ],
+        middleware=middleware,
+    )
+
+
+# Initialize FastMCP server with HTTP transport - same as SSE
+mcp = FastMCP("example-mcp-server")
+tool_service = ToolService()
+resource_service = ResourceService()
+
+# Register all tools and their MCP handlers - same as SSE
+tool_service.register_tools(get_available_tools())
+tool_service.register_mcp_handlers(mcp)
+
+# Register all resources and their MCP handlers - same as SSE  
+resource_service.register_resources(get_available_resources())
+resource_service.register_mcp_handlers(mcp)
+
+# Get the MCP server - same as SSE
+mcp_server = mcp._mcp_server  # noqa: WPS437
+
+# Create the Starlette app
+app = create_http_app(mcp_server)
+
+# Export the app
+__all__ = ["app"]
+
+
+def main():
+    """Entry point for the HTTP Stream Transport server."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run MCP HTTP Stream server")
+    parser.add_argument(
+        "--host", default="0.0.0.0", help="Host to bind to"
+    )
+    parser.add_argument(
+        "--port", type=int, default=6969, help="Port to listen on"
+    )
+    parser.add_argument(
+        "--reload", action="store_true", help="Enable auto-reload for development"
+    )
+    args = parser.parse_args()
+    
+    print(f"MCP HTTP Stream Server starting on {args.host}:{args.port}")
+    
+    uvicorn.run(
+        "example_mcp_server.server_http:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        reload_dirs=["example_mcp_server"],
+        timeout_graceful_shutdown=5,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
@@ -11,7 +11,6 @@ from mcp.server import Server
 from mcp.server.sse import SseServerTransport
 import uvicorn
 from typing import List
-import json
 
 from example_mcp_server.services.tool_service import ToolService
 from example_mcp_server.services.resource_service import ResourceService
@@ -37,10 +36,10 @@ def get_available_resources() -> List[Resource]:
 
 def create_http_app(mcp_server: Server) -> Starlette:
     """Create a Starlette app supporting HTTP Stream Transport."""
-    
+
     # Create SSE transport for handling the connection
     sse = SseServerTransport("/messages/")
-    
+
     async def handle_mcp(request: Request):
         """Handle MCP requests over HTTP Stream - accepts GET for connection."""
         try:
@@ -55,16 +54,9 @@ def create_http_app(mcp_server: Server) -> Starlette:
                     write_stream,
                     mcp_server.create_initialization_options(),
                 )
-                
+
         except Exception as e:
-            error_response = {
-                "jsonrpc": "2.0", 
-                "id": None,
-                "error": {
-                    "code": -32603,
-                    "message": f"Internal error: {str(e)}"
-                }
-            }
+            error_response = {"jsonrpc": "2.0", "id": None, "error": {"code": -32603, "message": f"Internal error: {str(e)}"}}
             return JSONResponse(error_response, status_code=500)
 
     middleware = [
@@ -95,7 +87,7 @@ resource_service = ResourceService()
 tool_service.register_tools(get_available_tools())
 tool_service.register_mcp_handlers(mcp)
 
-# Register all resources and their MCP handlers - same as SSE  
+# Register all resources and their MCP handlers - same as SSE
 resource_service.register_resources(get_available_resources())
 resource_service.register_mcp_handlers(mcp)
 
@@ -114,19 +106,13 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="Run MCP HTTP Stream server")
-    parser.add_argument(
-        "--host", default="0.0.0.0", help="Host to bind to"
-    )
-    parser.add_argument(
-        "--port", type=int, default=6969, help="Port to listen on"
-    )
-    parser.add_argument(
-        "--reload", action="store_true", help="Enable auto-reload for development"
-    )
+    parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
+    parser.add_argument("--port", type=int, default=6969, help="Port to listen on")
+    parser.add_argument("--reload", action="store_true", help="Enable auto-reload for development")
     args = parser.parse_args()
-    
+
     print(f"MCP HTTP Stream Server starting on {args.host}:{args.port}")
-    
+
     uvicorn.run(
         "example_mcp_server.server_http:app",
         host=args.host,

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_sse.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_sse.py
@@ -4,6 +4,7 @@ from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
 from mcp.server.sse import SseServerTransport
 from starlette.requests import Request
+from starlette.responses import Response
 from starlette.routing import Mount, Route
 from mcp.server import Server
 import uvicorn
@@ -37,7 +38,7 @@ def create_starlette_app(mcp_server: Server) -> Starlette:
     """Create a Starlette application that can serve the provided mcp server with SSE."""
     sse = SseServerTransport("/messages/")
 
-    async def handle_sse(request: Request) -> None:
+    async def handle_sse(request: Request) -> Response:
         async with sse.connect_sse(
             request.scope,
             request.receive,
@@ -48,6 +49,7 @@ def create_starlette_app(mcp_server: Server) -> Starlette:
                 write_stream,
                 mcp_server.create_initialization_options(),
             )
+        return Response("SSE connection closed", status_code=200)
 
     middleware = [
         Middleware(

--- a/atomic-examples/mcp-agent/example-mcp-server/poetry.lock
+++ b/atomic-examples/mcp-agent/example-mcp-server/poetry.lock
@@ -187,14 +187,14 @@ testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "mcp"
-version = "1.6.0"
+version = "1.9.4"
 description = "Model Context Protocol SDK"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0"},
-    {file = "mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723"},
+    {file = "mcp-1.9.4-py3-none-any.whl", hash = "sha256:7fcf36b62936adb8e63f89346bccca1268eeca9bf6dfb562ee10b1dfbda9dac0"},
+    {file = "mcp-1.9.4.tar.gz", hash = "sha256:cfb0bcd1a9535b42edaef89947b9e18a8feb49362e1cc059d6e7fc636f2cb09f"},
 ]
 
 [package.dependencies]
@@ -204,10 +204,11 @@ httpx-sse = ">=0.4"
 pydantic = ">=2.7.2,<3.0.0"
 pydantic-settings = ">=2.5.2"
 python-dotenv = {version = ">=1.0.0", optional = true, markers = "extra == \"cli\""}
+python-multipart = ">=0.0.9"
 sse-starlette = ">=1.6.1"
 starlette = ">=0.27"
 typer = {version = ">=0.12.4", optional = true, markers = "extra == \"cli\""}
-uvicorn = ">=0.23.1"
+uvicorn = {version = ">=0.23.1", markers = "sys_platform != \"emscripten\""}
 
 [package.extras]
 cli = ["python-dotenv (>=1.0.0)", "typer (>=0.12.4)"]
@@ -415,6 +416,18 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.20"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
+    {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
+]
+
+[[package]]
 name = "rich"
 version = "14.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -562,4 +575,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12.0"
-content-hash = "f019279978915791d091244ec047bc353fb0aaf920697afbceae26eb66783989"
+content-hash = "663898c480a56b759b24e25b495bcd8961217a2c01bdf47ad24f81b5afd21540"

--- a/atomic-examples/mcp-agent/example-mcp-server/pyproject.toml
+++ b/atomic-examples/mcp-agent/example-mcp-server/pyproject.toml
@@ -5,7 +5,7 @@ description = "example-mcp-server MCP server"
 authors = []
 requires-python = ">=3.12.0"
 dependencies = [
-    "mcp[cli]",
+    "mcp[cli]>=1.9.4",
     "rich>=13.0.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.15.0",

--- a/docs/examples/mcp_agent.md
+++ b/docs/examples/mcp_agent.md
@@ -4,7 +4,7 @@ This guide provides a detailed overview of the Model Context Protocol (MCP) serv
 
 ## Overview
 
-The MCP example demonstrates how to build an intelligent agent system using the Model Context Protocol, showcasing both server and client implementations. The example supports two transport methods: STDIO and Server-Sent Events (SSE).
+The MCP example demonstrates how to build an intelligent agent system using the Model Context Protocol, showcasing both server and client implementations. The example supports three transport methods: STDIO, Server-Sent Events (SSE), and HTTP Stream.
 
 ## Architecture
 
@@ -19,6 +19,7 @@ Key components:
 1. **Transport Layers**:
    - `server_stdio.py`: Implements STDIO-based communication
    - `server_sse.py`: Implements SSE-based HTTP communication
+   - `server_http.py`: Implements unified HTTP streaming transport 
 
 2. **Tools Service**:
    - Manages registration and execution of MCP tools
@@ -56,7 +57,7 @@ The client component (`example-client`) is an intelligent agent that:
 
 ### Server Implementation
 
-The server supports two transport methods:
+The server supports three transport methods:
 
 1. **SSE Transport** (`server_sse.py`):
 ```python
@@ -75,6 +76,10 @@ app = create_starlette_app(mcp_server)
 - Runs as a subprocess
 - Communicates through standard input/output
 - Ideal for local development
+
+3. **HTTP Stream Transport** (`server_http.py`):
+- Single `/mcp` endpoint for JSON-RPC and SSE-style streaming
+- Handles session via `Mcp-Session-Id` header; allows resumable and cancelable streams
 
 ### Client Implementation
 


### PR DESCRIPTION
### My Summary
SSE support for MCP servers has been deprecated in favor of Streamable HTTP. This change updates MCPToolFactory to use HTTP_STREAM as the default transport while still supporting SSE for legacy clients.

This is the initial PR to gather feedback

Refs #134

### GITHUB COPILOT SUMMARY OF CHANGES
This pull request refactors the MCP transport mechanism by replacing the `use_stdio` boolean flag with a more extensible `MCPTransportType` enum. It supports multiple transport types (`SSE`, `HTTP_STREAM`, `STDIO`) and improves clarity and maintainability across the factory, service, and test layers.

**Core Refactoring: Transport Mechanism**
- Introduced `MCPTransportType` enum in `tool_definition_service.py` to represent transport types.
- Replaced `use_stdio` flag with `transport_type` enum; default is now `HTTP_STREAM`.
- Added validation for unknown transport types, raising `ValueError` for invalid values.

**Transport-Specific Logic**
- Added support for `HTTP_STREAM` in `_connect_and_call` and `fetch_definitions`, handling trailing slashes.
- Marked `SSE` transport as deprecated in logs.

**Public API Updates**
- Updated `fetch_mcp_tools` and `fetch_mcp_tools_with_schema` to accept `transport_type` instead of `use_stdio`.

**Test Suite Adjustments**
- Refactored tests in `test_mcp_tool_factory.py` to use `MCPTransportType` and added parameterized tests for each enum value.
