### PR TITLE
Fix type hinting in BaseTool.run()

### DIFF
--- a/atomic-agents/atomic_agents/lib/base/base_tool.py
+++ b/atomic-agents/atomic_agents/lib/base/base_tool.py
@@ -41,7 +41,7 @@ class BaseTool:
         self.tool_name = config.title or self.input_schema.model_json_schema()["title"]
         self.tool_description = config.description or self.input_schema.model_json_schema()["description"]
 
-    def run(self, params: Type[BaseIOSchema]) -> BaseIOSchema:
+    def run(self, params: BaseIOSchema) -> BaseIOSchema:
         """
         Executes the tool with the provided parameters.
 


### PR DESCRIPTION
Thanks for this, I love it and I am completely overthinking my own project that uses it 🙂

However, I think the type hinting is wrong in this function, or at least it's confusing the hell out of me 😂