### PR TITLE
Fix AgentMemory issues

### DIFF
--- a/atomic-agents/atomic_agents/lib/components/agent_memory.py
+++ b/atomic-agents/atomic_agents/lib/components/agent_memory.py
@@ -1,7 +1,8 @@
 import json
 import uuid
-from typing import Dict, List, Optional, Type
+from enum import Enum
 from pathlib import Path
+from typing import Dict, List, Optional, Type
 
 from instructor.multimodal import PDF, Image, Audio
 from pydantic import BaseModel, Field
@@ -283,7 +284,7 @@ class AgentMemory:
             for field_name in obj.model_fields:
                 if hasattr(obj, field_name):
                     self._process_multimodal_paths(getattr(obj, field_name))
-        elif hasattr(obj, "__dict__"):
+        elif hasattr(obj, "__dict__") and not isinstance(obj, Enum):
             # Process each attribute of the object
             for attr_name, attr_value in obj.__dict__.items():
                 if attr_name != "__pydantic_fields_set__":  # Skip pydantic internal fields

--- a/atomic-agents/atomic_agents/lib/components/agent_memory.py
+++ b/atomic-agents/atomic_agents/lib/components/agent_memory.py
@@ -115,12 +115,12 @@ class AgentMemory:
                         if isinstance(item, INSTRUCTOR_MULTIMODAL_TYPES):
                             processed_content.append(item)
                         else:
-                            processed_content.append(json.dumps({field_name: field_value}))
+                            processed_content.append(input_content.model_dump_json(include=field_name))
                 else:
                     if isinstance(field_value, INSTRUCTOR_MULTIMODAL_TYPES):
                         processed_content.append(field_value)
                     else:
-                        processed_content.append(json.dumps({field_name: field_value}))
+                        processed_content.append(input_content.model_dump_json(include=field_name))
 
             history.append({"role": message.role, "content": processed_content})
 

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -363,6 +363,43 @@ def test_agent_memory_delete_turn_id(memory):
         memory.delete_turn_id("non-existent-id")
 
 
+def test_get_history_nested_model(memory):
+    """Test that get_history works with nested models."""
+    # Add complex input
+    memory.add_message(
+        "user",
+        TestComplexInputSchema(
+            text_field="Complex input",
+            number_field=2.718,
+            list_field=["a", "b", "c"],
+            nested_field=TestNestedSchema(nested_field="Nested input", nested_int=99),
+        ),
+    )
+
+    # Add complex output
+    memory.add_message(
+        "assistant",
+        TestComplexOutputSchema(
+            response_text="Complex output",
+            calculated_value=200,
+            data_dict={
+                "key1": TestNestedSchema(nested_field="Nested output 1", nested_int=10),
+                "key2": TestNestedSchema(nested_field="Nested output 2", nested_int=20),
+            },
+        ),
+    )
+
+    # Get history and verify the format
+    history = memory.get_history()
+
+    assert len(history) == 2
+    assert history[0]["role"] == "user"
+    assert history[1]["role"] == "assistant"
+
+    assert history[0]["content"][0] == '{"text_field":"Complex input"}'
+    assert history[1]["content"][0] == '{"response_text":"Complex output"}'
+
+
 def test_get_history_with_multimodal_content(memory):
     """Test that get_history correctly handles multimodal content"""
     # Create a mock image

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -418,7 +418,7 @@ def test_get_history_with_multimodal_content(memory):
     assert len(history) == 1
     assert history[0]["role"] == "user"
     assert isinstance(history[0]["content"], list)
-    assert history[0]["content"][0] == '{"instruction_text": "Analyze this image"}'
+    assert history[0]["content"][0] == '{"instruction_text":"Analyze this image"}'
     assert history[0]["content"][1] == mock_image
     assert history[0]["content"][2] == mock_pdf
     assert history[0]["content"][3] == mock_audio
@@ -454,7 +454,7 @@ def test_get_history_with_multiple_images_multimodal_content(memory):
     assert len(history) == 1
     assert history[0]["role"] == "user"
     assert isinstance(history[0]["content"], list)
-    assert history[0]["content"][0] == '{"instruction_text": "Analyze this image"}'
+    assert history[0]["content"][0] == '{"instruction_text":"Analyze this image"}'
     assert mock_image in history[0]["content"]
     assert mock_image_2 in history[0]["content"]
     assert mock_image_3 in history[0]["content"]

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -61,6 +61,7 @@ class ColorEnum(str, Enum):
 
 class TestEnumSchema(BaseIOSchema):
     """Test Input Schema with Enum."""
+
     color: ColorEnum = Field(..., description="Some color.")
 
 

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 import pytest
 import json
 from typing import List, Dict
@@ -50,6 +52,16 @@ class TestMultimodalSchema(BaseIOSchema):
     images: List[instructor.Image] = Field(..., description="The images to analyze")
     pdfs: List[instructor.multimodal.PDF] = Field(..., description="The PDFs to analyze")
     audio: instructor.multimodal.Audio = Field(..., description="The Audio to analyze")
+
+
+class ColorEnum(str, Enum):
+    BLUE = "blue"
+    RED = "red"
+
+
+class TestEnumSchema(BaseIOSchema):
+    """Test Input Schema with Enum."""
+    color: ColorEnum = Field(..., description="Some color.")
 
 
 @pytest.fixture
@@ -190,6 +202,25 @@ def test_dump_and_load_multimodal_data(memory):
     assert new_memory.history[0].content.images == memory.history[0].content.images
     assert new_memory.history[0].content.pdfs == memory.history[0].content.pdfs
     assert new_memory.history[0].content.audio == memory.history[0].content.audio
+
+
+def test_dump_and_load_with_enum(memory):
+    """Test that get_history works with Enum."""
+
+    memory.add_message(
+        "user",
+        TestEnumSchema(
+            color=ColorEnum.RED,
+        ),
+    )
+
+    dumped_data = memory.dump()
+    new_memory = AgentMemory()
+    new_memory.load(dumped_data)
+
+    assert new_memory.max_messages == memory.max_messages
+    assert new_memory.current_turn_id == memory.current_turn_id
+    assert len(new_memory.history) == len(memory.history)
 
 
 def test_load_invalid_data(memory):


### PR DESCRIPTION
Adresses the following:

- https://github.com/BrainBlend-AI/atomic-agents/issues/144
- https://github.com/BrainBlend-AI/atomic-agents/issues/145
- https://github.com/BrainBlend-AI/atomic-agents/issues/138

Main changes:
- Use pydantic serializer in `AgentMemory.get_history`: fixe the issue for nested pydantic models and unicode escaping
- Avoid infinite recursion in `AgentMemory._process_multimodal_paths` by checking for Enum type.