### PR TITLE
fix: resolve memory duplication bug when processing list fields

### DIFF
--- a/atomic-agents/atomic_agents/lib/components/agent_memory.py
+++ b/atomic-agents/atomic_agents/lib/components/agent_memory.py
@@ -111,16 +111,18 @@ class AgentMemory:
                 field_value = getattr(input_content, field_name)
 
                 if isinstance(field_value, list):
+                    has_multimodal_in_list = False
                     for item in field_value:
                         if isinstance(item, INSTRUCTOR_MULTIMODAL_TYPES):
                             processed_content.append(item)
-                        else:
-                            processed_content.append(input_content.model_dump_json(include=field_name))
+                            has_multimodal_in_list = True
+                    if not has_multimodal_in_list:
+                        processed_content.append(input_content.model_dump_json(include={field_name}))
                 else:
                     if isinstance(field_value, INSTRUCTOR_MULTIMODAL_TYPES):
                         processed_content.append(field_value)
                     else:
-                        processed_content.append(input_content.model_dump_json(include=field_name))
+                        processed_content.append(input_content.model_dump_json(include={field_name}))
 
             history.append({"role": message.role, "content": processed_content})
 

--- a/atomic-agents/tests/lib/components/test_agent_memory.py
+++ b/atomic-agents/tests/lib/components/test_agent_memory.py
@@ -459,3 +459,34 @@ def test_get_history_with_multiple_images_multimodal_content(memory):
     assert mock_image in history[0]["content"]
     assert mock_image_2 in history[0]["content"]
     assert mock_image_3 in history[0]["content"]
+
+
+def test_process_multimodal_paths_with_dict_object():
+    """Test that _process_multimodal_paths handles objects with __dict__ correctly"""
+    from pathlib import Path
+
+    class CustomObject:
+        """A custom object with __dict__ that isn't a Pydantic model or Enum"""
+
+        def __init__(self):
+            self.image = instructor.Image(source="test_path.jpg", media_type="image/jpeg")
+            self.text = "some text"
+            self.nested = None
+
+    # Create test object
+    custom_obj = CustomObject()
+    custom_obj.nested = CustomObject()  # Nested object to test recursion
+
+    # Create a memory instance to access the method
+    memory = AgentMemory()
+
+    # Call _process_multimodal_paths directly
+    memory._process_multimodal_paths(custom_obj)
+
+    # Verify the image path was converted
+    assert isinstance(custom_obj.image.source, Path)
+    assert custom_obj.image.source == Path("test_path.jpg")
+
+    # Verify nested object was also processed
+    assert isinstance(custom_obj.nested.image.source, Path)
+    assert custom_obj.nested.image.source == Path("test_path.jpg")


### PR DESCRIPTION
  - Fixed get_history() method in AgentMemory to prevent duplicate message entries
  - Non-multimodal list fields are now serialized once per field instead of per item
  - Added test for _process_multimodal_paths edge case to achieve 100% coverage
  - Updated example comments in base_agent.py to reflect the fix