### PR TITLE
Feature/mcp input schema fix 164

### DIFF
--- a/atomic-agents/atomic_agents/connectors/mcp/schema_transformer.py
+++ b/atomic-agents/atomic_agents/connectors/mcp/schema_transformer.py
@@ -1,7 +1,7 @@
 """Module for transforming JSON schemas to Pydantic models."""
 
 import logging
-from typing import Any, Dict, List, Optional, Type, Tuple, Literal, cast
+from typing import Any, Dict, List, Optional, Type, Tuple, Literal, Union, cast
 
 from pydantic import Field, create_model
 
@@ -24,33 +24,113 @@ class SchemaTransformer:
     """Class for transforming JSON schemas to Pydantic models."""
 
     @staticmethod
-    def json_to_pydantic_field(prop_schema: Dict[str, Any], required: bool) -> Tuple[Type, Field]:
+    def _resolve_ref(ref_path: str, root_schema: Dict[str, Any], model_cache: Dict[str, Type]) -> Type:
+        """Resolve a $ref to a Pydantic model."""
+        # Extract ref name from path like "#/$defs/MyObject" or "#/definitions/ANode"
+        ref_name = ref_path.split("/")[-1]
+
+        if ref_name in model_cache:
+            return model_cache[ref_name]
+
+        # Look for the referenced schema in $defs or definitions
+        defs = root_schema.get("$defs", root_schema.get("definitions", {}))
+        if ref_name in defs:
+            ref_schema = defs[ref_name]
+            # Create model for the referenced schema
+            model_name = ref_schema.get("title", ref_name)
+            # Avoid infinite recursion by adding placeholder first
+            model_cache[ref_name] = Any
+            model = SchemaTransformer._create_nested_model(ref_schema, model_name, root_schema, model_cache)
+            model_cache[ref_name] = model
+            return model
+
+        logger.warning(f"Could not resolve $ref: {ref_path}")
+        return Any
+
+    @staticmethod
+    def _create_nested_model(
+        schema: Dict[str, Any], model_name: str, root_schema: Dict[str, Any], model_cache: Dict[str, Type]
+    ) -> Type:
+        """Create a nested Pydantic model from a schema."""
+        fields = {}
+        required_fields = set(schema.get("required", []))
+        properties = schema.get("properties", {})
+
+        for prop_name, prop_schema in properties.items():
+            is_required = prop_name in required_fields
+            fields[prop_name] = SchemaTransformer.json_to_pydantic_field(prop_schema, is_required, root_schema, model_cache)
+
+        return create_model(model_name, **fields)
+
+    @staticmethod
+    def json_to_pydantic_field(
+        prop_schema: Dict[str, Any],
+        required: bool,
+        root_schema: Optional[Dict[str, Any]] = None,
+        model_cache: Optional[Dict[str, Type]] = None,
+    ) -> Tuple[Type, Field]:
         """
         Convert a JSON schema property to a Pydantic field.
 
         Args:
             prop_schema: JSON schema for the property
             required: Whether the field is required
+            root_schema: Full root schema for resolving $refs
+            model_cache: Cache for resolved models
 
         Returns:
             Tuple of (type, Field)
         """
-        json_type = prop_schema.get("type")
+        if root_schema is None:
+            root_schema = {}
+        if model_cache is None:
+            model_cache = {}
+
         description = prop_schema.get("description")
         default = prop_schema.get("default")
         python_type: Any = Any
 
-        if json_type in JSON_TYPE_MAP:
-            python_type = JSON_TYPE_MAP[json_type]
-            if json_type == "array":
-                items_schema = prop_schema.get("items", {})
-                item_type_str = items_schema.get("type")
-                if item_type_str in JSON_TYPE_MAP:
-                    python_type = List[JSON_TYPE_MAP[item_type_str]]
+        # Handle $ref
+        if "$ref" in prop_schema:
+            python_type = SchemaTransformer._resolve_ref(prop_schema["$ref"], root_schema, model_cache)
+        # Handle oneOf/anyOf (unions)
+        elif "oneOf" in prop_schema or "anyOf" in prop_schema:
+            union_schemas = prop_schema.get("oneOf", prop_schema.get("anyOf", []))
+            if union_schemas:
+                union_types = []
+                for union_schema in union_schemas:
+                    if "$ref" in union_schema:
+                        union_types.append(SchemaTransformer._resolve_ref(union_schema["$ref"], root_schema, model_cache))
+                    else:
+                        # Recursively resolve the union member
+                        member_type, _ = SchemaTransformer.json_to_pydantic_field(union_schema, True, root_schema, model_cache)
+                        union_types.append(member_type)
+
+                if len(union_types) == 1:
+                    python_type = union_types[0]
                 else:
-                    python_type = List[Any]
-            elif json_type == "object":
-                python_type = Dict[str, Any]
+                    python_type = Union[tuple(union_types)]
+        # Handle regular types
+        else:
+            json_type = prop_schema.get("type")
+            if json_type in JSON_TYPE_MAP:
+                python_type = JSON_TYPE_MAP[json_type]
+
+                if json_type == "array":
+                    items_schema = prop_schema.get("items", {})
+                    if "$ref" in items_schema:
+                        item_type = SchemaTransformer._resolve_ref(items_schema["$ref"], root_schema, model_cache)
+                    elif "oneOf" in items_schema or "anyOf" in items_schema:
+                        # Handle arrays of unions
+                        item_type, _ = SchemaTransformer.json_to_pydantic_field(items_schema, True, root_schema, model_cache)
+                    elif items_schema.get("type") in JSON_TYPE_MAP:
+                        item_type = JSON_TYPE_MAP[items_schema["type"]]
+                    else:
+                        item_type = Any
+                    python_type = List[item_type]
+
+                elif json_type == "object":
+                    python_type = Dict[str, Any]
 
         field_kwargs = {"description": description}
         if required:
@@ -85,11 +165,12 @@ class SchemaTransformer:
         fields = {}
         required_fields = set(schema.get("required", []))
         properties = schema.get("properties")
+        model_cache: Dict[str, Type] = {}
 
         if properties:
             for prop_name, prop_schema in properties.items():
                 is_required = prop_name in required_fields
-                fields[prop_name] = SchemaTransformer.json_to_pydantic_field(prop_schema, is_required)
+                fields[prop_name] = SchemaTransformer.json_to_pydantic_field(prop_schema, is_required, schema, model_cache)
         elif schema.get("type") == "object" and not properties:
             pass
         elif schema:

--- a/atomic-examples/mcp-agent/example-client/example_client/main_fastapi.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_fastapi.py
@@ -20,7 +20,7 @@ class MCPConfig:
     """Configuration for the MCP Agent system using HTTP Stream transport."""
 
     mcp_server_url: str = "http://localhost:6969"
-    openai_model: str = "gpt-4o"
+    openai_model: str = "gpt-5-mini"
     openai_api_key: str = os.getenv("OPENAI_API_KEY") or ""
 
     def __post_init__(self):

--- a/atomic-examples/mcp-agent/example-client/example_client/main_http.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_http.py
@@ -23,7 +23,7 @@ class MCPConfig:
     """Configuration for the MCP Agent system using HTTP Stream transport."""
 
     mcp_server_url: str = "http://localhost:6969"
-    openai_model: str = "gpt-4o"
+    openai_model: str = "gpt-5-mini"
     openai_api_key: str = os.getenv("OPENAI_API_KEY")
 
     def __post_init__(self):

--- a/atomic-examples/mcp-agent/example-client/example_client/main_sse.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_sse.py
@@ -21,11 +21,11 @@ class MCPConfig:
 
     mcp_server_url: str = "http://localhost:6969"
 
-    # NOTE: In contrast to other examples, we use gpt-4o and not gpt-4o-mini here.
-    # In my tests, gpt-4o-mini was not smart enough to deal with multiple tools like that
+    # NOTE: In contrast to other examples, we use gpt-5-mini and not gpt-4o-mini here.
+    # In my tests, gpt-5-mini was not smart enough to deal with multiple tools like that
     # and at the moment MCP does not yet allow for adding sufficient metadata to
     # clarify tools even more and introduce more constraints.
-    openai_model: str = "gpt-4o"
+    openai_model: str = "gpt-5-mini"
     openai_api_key: str = os.getenv("OPENAI_API_KEY")
 
     def __post_init__(self):

--- a/atomic-examples/mcp-agent/example-client/example_client/main_stdio.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_stdio.py
@@ -22,11 +22,11 @@ from mcp.client.stdio import stdio_client
 class MCPConfig:
     """Configuration for the MCP Agent system using STDIO transport."""
 
-    # NOTE: In contrast to other examples, we use gpt-4o and not gpt-4o-mini here.
-    # In my tests, gpt-4o-mini was not smart enough to deal with multiple tools like that
+    # NOTE: In contrast to other examples, we use gpt-5-mini and not gpt-5-mini here.
+    # In my tests, gpt-5-mini was not smart enough to deal with multiple tools like that
     # and at the moment MCP does not yet allow for adding sufficient metadata to
     # clarify tools even more and introduce more constraints.
-    openai_model: str = "gpt-4o"
+    openai_model: str = "gpt-5-mini"
     openai_api_key: str = os.getenv("OPENAI_API_KEY")
 
     # Command to run the STDIO server.

--- a/atomic-examples/mcp-agent/example-client/example_client/main_stdio_async.py
+++ b/atomic-examples/mcp-agent/example-client/example_client/main_stdio_async.py
@@ -22,11 +22,11 @@ from mcp.client.stdio import stdio_client
 class MCPConfig:
     """Configuration for the MCP Agent system using STDIO transport."""
 
-    # NOTE: In contrast to other examples, we use gpt-4o and not gpt-4o-mini here.
-    # In my tests, gpt-4o-mini was not smart enough to deal with multiple tools like that
+    # NOTE: In contrast to other examples, we use gpt-5-mini and not gpt-4o-mini here.
+    # In my tests, gpt-5-mini was not smart enough to deal with multiple tools like that
     # and at the moment MCP does not yet allow for adding sufficient metadata to
     # clarify tools even more and introduce more constraints.
-    openai_model: str = "gpt-4o"
+    openai_model: str = "gpt-5-mini"
     openai_api_key: str = os.getenv("OPENAI_API_KEY")
 
     # Command to run the STDIO server.

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/server_http.py
@@ -17,6 +17,7 @@ from example_mcp_server.tools import (
     SubtractNumbersTool,
     MultiplyNumbersTool,
     DivideNumbersTool,
+    BatchCalculatorTool,
 )
 
 
@@ -27,6 +28,7 @@ def get_available_tools() -> List[Tool]:
         SubtractNumbersTool(),
         MultiplyNumbersTool(),
         DivideNumbersTool(),
+        BatchCalculatorTool(),
     ]
 
 

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/services/tool_service.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/services/tool_service.py
@@ -42,7 +42,6 @@ class ToolService:
         """
         tool = self.get_tool(tool_name)
 
-
         # Use model_validate to handle complex nested objects properly
         input_model = tool.input_model.model_validate(input_data)
 

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/services/tool_service.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/services/tool_service.py
@@ -3,7 +3,6 @@
 from typing import Dict, List, Any
 from mcp.server.fastmcp import FastMCP
 from example_mcp_server.interfaces.tool import Tool, ToolResponse, ToolContent
-from pydantic import Field
 
 
 class ToolService:
@@ -43,8 +42,9 @@ class ToolService:
         """
         tool = self.get_tool(tool_name)
 
-        # Convert input dictionary to the tool's input model
-        input_model = tool.input_model(**input_data)
+
+        # Use model_validate to handle complex nested objects properly
+        input_model = tool.input_model.model_validate(input_data)
 
         # Execute the tool with validated input
         return await tool.execute(input_model)
@@ -90,41 +90,19 @@ class ToolService:
     def register_mcp_handlers(self, mcp: FastMCP) -> None:
         """Register all tools as MCP handlers."""
         for tool in self._tools.values():
-            # Get the tool's schema
-            schema = tool.input_model.model_json_schema()
-            properties = schema.get("properties", {})
+            # Create a handler that uses the tool's input model directly for schema generation
+            def create_handler(tool_instance):
+                # Use the actual Pydantic model as the function parameter
+                # This ensures FastMCP gets the complete schema including nested objects
+                async def handler(input_data: tool_instance.input_model):
+                    f'"""{tool_instance.description}"""'
+                    result = await self.execute_tool(tool_instance.name, input_data.model_dump())
+                    return self._serialize_response(result)
 
-            # Create a function signature that matches the schema with parameter descriptions
-            params = []
+                return handler
 
-            for name, info in properties.items():
-                type_hint = "str"  # Default to str
-                if info.get("type") == "integer":
-                    type_hint = "int"
-                elif info.get("type") == "number":
-                    type_hint = "float"
-                elif info.get("type") == "boolean":
-                    type_hint = "bool"
+            # Create the handler
+            handler = create_handler(tool)
 
-                default = info.get("default", "...")
-                description = info.get("description", "")
-
-                # Create parameter string for function definition with Field for descriptions
-                if default == "...":
-                    params.append(f"{name}: {type_hint} = Field(description='{description}')")
-                else:
-                    params.append(f"{name}: {type_hint} = Field(description='{description}', default={repr(default)})")
-
-            # Create the function definition
-            fn_def = f"async def {tool.name}({', '.join(params)}):\n"
-            fn_def += f'    """{tool.description}"""\n'
-            fn_def += "    result = await self.execute_tool(tool.name, locals())\n"
-            fn_def += "    return self._serialize_response(result)"
-
-            # Create the function
-            namespace = {"self": self, "tool": tool, "Field": Field}
-            exec(fn_def, namespace)
-            handler = namespace[tool.name]
-
-            # Register the handler
+            # Register with FastMCP - it should auto-detect the schema from the type annotation
             mcp.tool(name=tool.name, description=tool.description)(handler)

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/tools/__init__.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/tools/__init__.py
@@ -4,13 +4,13 @@ from .add_numbers import AddNumbersTool
 from .subtract_numbers import SubtractNumbersTool
 from .multiply_numbers import MultiplyNumbersTool
 from .divide_numbers import DivideNumbersTool
-
-# Remove unused tools like DateDifferenceTool, ReverseStringTool, CurrentTimeTool, RandomNumberTool if they are not defined
+from .batch_operations import BatchCalculatorTool
 
 __all__ = [
     "AddNumbersTool",
     "SubtractNumbersTool",
     "MultiplyNumbersTool",
     "DivideNumbersTool",
+    "BatchCalculatorTool",
     # Add additional tools to the __all__ list as you create them
 ]

--- a/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/tools/batch_operations.py
+++ b/atomic-examples/mcp-agent/example-mcp-server/example_mcp_server/tools/batch_operations.py
@@ -1,0 +1,76 @@
+# Tool: BatchCalculatorTool
+from typing import List, Union, Literal, Annotated, Dict, Any
+from pydantic import BaseModel, Field, ConfigDict
+from ..interfaces.tool import Tool, BaseToolInput, ToolResponse
+
+
+# ---- ops (discriminated union) ----
+class Add(BaseModel):
+    op: Literal["add"]
+    nums: List[float] = Field(min_items=1)
+
+
+class Mul(BaseModel):
+    op: Literal["mul"]
+    nums: List[float] = Field(min_items=1)
+
+
+Op = Annotated[Union[Add, Mul], Field(discriminator="op")]
+
+
+# ---- IO ----
+class BatchInput(BaseToolInput):
+    model_config = ConfigDict(
+        title="BatchInput",
+        json_schema_extra={
+            "examples": [{"mode": "sum", "tasks": [{"op": "add", "nums": [1, 2, 3]}, {"op": "mul", "nums": [2, 3]}]}]
+        },
+    )
+    tasks: List[Op] = Field(description="List of operations to run (add|mul)")
+    mode: Literal["sum", "avg"] = Field(default="sum", description="Combine per-task results by sum or average")
+    explain: bool = False
+
+
+class BatchOutput(BaseModel):
+    results: List[float]
+    combined: float
+    mode_used: Literal["sum", "avg"]
+    summary: str | None = None
+
+
+# ---- Tool ----
+class BatchCalculatorTool(Tool):
+    name = "BatchCalculator"
+    description = (
+        "Run a batch of simple ops. \nExamples:\n"
+        '- {"tasks":[{"op":"add","nums":[1,2,3]}, {"op":"mul","nums":[4,5]}], "mode":"sum"}\n'
+        '- {"tasks":[{"op":"mul","nums":[2,3,4]}], "mode":"avg"}\n'
+        '- {"tasks":[{"op":"add","nums":[10,20]}, {"op":"add","nums":[30,40]}], "mode":"avg"}'
+    )
+    input_model = BatchInput
+    output_model = BatchOutput
+
+    def get_schema(self) -> Dict[str, Any]:
+        inp = self.input_model.model_json_schema()
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input": inp,
+            "output": self.output_model.model_json_schema(),
+            "examples": inp.get("examples", []),
+        }
+
+    async def execute(self, data: BatchInput) -> ToolResponse:
+        def run(op: Op) -> float:
+            if op.op == "add":
+                return float(sum(op.nums))
+            prod = 1.0
+            for x in op.nums:
+                prod *= float(x)
+            return prod
+
+        results = [run(t) for t in data.tasks]
+        combined = float(sum(results)) if data.mode == "sum" else (float(sum(results)) / len(results) if results else 0.0)
+        summary = (f"tasks={len(results)}, results={results}, combined={combined} ({data.mode})") if data.explain else None
+
+        return ToolResponse.from_model(BatchOutput(results=results, combined=combined, mode_used=data.mode, summary=summary))


### PR DESCRIPTION
*My Summary*

Preserve `Union` and list element model types when generating Pydantic models from MCP tool schemas, resolving issue #164 where these degraded to `Any`. Added additional Batch Tool to test with complex models and nested types.

Updated mcp clients from gpt-4o to gpt-5-mini

Included this in the client itself to check the output to ensure its handling the nested types properly

```
Initializing MCP Agent System (HTTP Stream mode)...
[BatchCalculator] <class 'atomic_agents.connectors.mcp.schema_transformer.BatchInput'>
  tasks: List[typing.Union[atomic_agents.connectors.mcp.schema_transformer.Add,
                           atomic_agents.connectors.mcp.schema_transformer.Mul]]
  mode: <class 'str'>
  explain: <class 'bool'>

```

```
from typing import Union, Type, Dict, List, get_origin, get_args

check_types(tools, debug=False)

def check_types(tools, name_substr="batch", debug=False):
    if not debug:
        return

    for t in tools:
        n = getattr(t, "mcp_tool_name", getattr(t, "name", ""))
        if name_substr.lower() not in n.lower():
            continue
        M = getattr(t, "input_schema", None)
        f = M and M.model_fields.get("input_data")
        if not f:
            print(f"[{n}] missing input_data")
            return
        Inner = f.annotation
        print(f"[{n}] {Inner}")
        for k, fld in getattr(Inner, "model_fields", {}).items():
            ann, org, args = fld.annotation, get_origin(fld.annotation), get_args(fld.annotation)
            if org in (list, List):
                it = args[0] if args else None
                print(f"  {k}: List[{it}]")
                if str(it) == "typing.Any":
                    print("    note: List item is Any")
            elif org is Union:
                print(f"  {k}: Union{args}")
                if any(str(a) == "typing.Any" for a in args):
                    print("    note: Union contains Any")
            else:
                print(f"  {k}: {ann}")
        return

```

*Github Copilot Summary*

This pull request introduces significant improvements to the MCP schema transformation logic and updates the MCP example configurations and tools. The most notable changes are the enhanced support for nested and union types in JSON schema-to-Pydantic model conversion, improved test coverage, and the addition of a new batch calculator tool. Configuration files are also updated to use the `gpt-5-mini` model.

**Schema transformation and validation improvements:**

* Enhanced `SchemaTransformer` to support `$ref` resolution, nested models, and union types (`oneOf`/`anyOf`) when converting JSON schemas to Pydantic models, ensuring correct typing for complex schemas. [[1]](diffhunk://#diff-94e1c971660524f59d9cc3189d8279a231386e84e6aa922c4b9b7a37b097ca19L27-R131) [[2]](diffhunk://#diff-94e1c971660524f59d9cc3189d8279a231386e84e6aa922c4b9b7a37b097ca19R168-R173)
* Updated tests in `test_schema_transformer.py` to cover union types, arrays with references, and complex nested schemas, verifying correct type inference and model creation.

**MCP tool and service updates:**

* Refactored tool execution in `ToolService` to use Pydantic's `model_validate`, improving handling of nested and complex input data.
* Simplified MCP handler registration to use Pydantic models directly for schema generation, enabling FastMCP to auto-detect nested schemas and union types.

**Tooling and configuration updates:**

* Added `BatchCalculatorTool` to the available tools and updated relevant imports and registration logic. [[1]](diffhunk://#diff-0decc4bc63e0399e02d9437a99da2e2f6f3449a9fe79cc38c12b4582362c949cR20) [[2]](diffhunk://#diff-0decc4bc63e0399e02d9437a99da2e2f6f3449a9fe79cc38c12b4582362c949cR31) [[3]](diffhunk://#diff-cdeedb1867fef0813edb9369087bbc0d4a55f4359743cd6185dfe8995a292556L7-R14)
* Changed default OpenAI model in all MCP example client configs from `gpt-4o` to `gpt-5-mini` for consistency and improved performance. [[1]](diffhunk://#diff-c42a19e9092b71aa8a745eef9f48d26dc63abd3c57738335d1805f59af2421f9L23-R23) [[2]](diffhunk://#diff-212ae1c0307bf6261a8ae5248e168fc007f86db8e42ea7e2265deaf3f97c18fdL26-R26) [[3]](diffhunk://#diff-c593c58bd97dfc31ca432dbcffe60d7fb04e7dbecda75baffd3902b86472c9eaL24-R28) [[4]](diffhunk://#diff-417aeb759e984f3ae3f4573601f241da42f3774bda9ef88b7ea0a92bd01c22a3L25-R29) [[5]](diffhunk://#diff-1edcb18437fee23c1b1d4cb6f00bb5b80cf148b92a617f67036c63d8519a2644L25-R29)