### PR TITLE
Fix: Generic type parameters not preserved when subclassing AtomicAgent

### DIFF
--- a/atomic-agents/tests/agents/test_atomic_agent.py
+++ b/atomic-agents/tests/agents/test_atomic_agent.py
@@ -242,6 +242,32 @@ def test_custom_input_output_schemas(mock_instructor):
     assert custom_agent.output_schema == CustomOutputSchema
 
 
+def test_subclass_with_custom_constructor(mock_instructor):
+    """Test that generic types are preserved in subclasses with custom constructors."""
+
+    class CustomInputSchema(BaseModel):
+        custom_field: str
+
+    class CustomOutputSchema(BaseModel):
+        result: str
+
+    class MyAgent(AtomicAgent[CustomInputSchema, CustomOutputSchema]):
+        def __init__(self, extra_param: str):
+            self.extra_param = extra_param
+            config = AgentConfig(
+                client=mock_instructor,
+                model="gpt-4o-mini",
+            )
+            super().__init__(config)
+
+    agent = MyAgent("test_value")
+
+    # These would fail without the __init_subclass__ fix
+    assert agent.input_schema == CustomInputSchema
+    assert agent.output_schema == CustomOutputSchema
+    assert agent.extra_param == "test_value"
+
+
 def test_base_agent_io_str_and_rich():
     class TestIO(BaseIOSchema):
         """TestIO docstring"""


### PR DESCRIPTION
## Problem

When you subclass `AtomicAgent` with a custom constructor, the generic type parameters get lost. The `input_schema` and `output_schema` properties end up returning `BasicChatInputSchema` and `BasicChatOutputSchema` instead of the types you actually specified.

Example that was broken:
```python
class MyAgent(AtomicAgent[MyInputSchema, MyOutputSchema]):
    def __init__(self, extra_param):
        self.extra_param = extra_param
        super().__init__(config)

agent = MyAgent("test")
# These would incorrectly return Basic* schemas instead of My* schemas
print(agent.input_schema)
print(agent.output_schema)
```

The issue is that `__orig_class__` only gets set for direct instantiation, not when subclassing.

## Solution

Added `__init_subclass__` to capture the generic parameters at class creation time. This is the same approach already used by `BasePrompt`, `BaseTool`, and `BaseResource`, so it's consistent with the codebase.

The schema properties now check in this order:
1. Class attributes (set by `__init_subclass__`) - handles subclassing
2. Instance `__orig_class__` - handles direct instantiation  
3. Default schemas - handles untyped usage

## Testing

- Added `test_subclass_with_custom_constructor()` to verify the fix
- All existing tests still pass (35/35)
- Code formatted and linted

## Notes

This is backward compatible - doesn't break any existing usage patterns. Direct instantiation still works the same way it did before.