### PR TITLE
Docs: add framework comparison guide

### DIFF
--- a/docs/guides/framework_comparison.md
+++ b/docs/guides/framework_comparison.md
@@ -1,0 +1,143 @@
+# Comparing Atomic Agents with Other AI Agent Frameworks
+
+This guide helps you understand how Atomic Agents compares to other popular frameworks when building AI applications.
+
+## Quick Comparison
+
+| Framework | Best For | Key Characteristic |
+|-----------|----------|-------------------|
+| **Atomic Agents** | Structured outputs, predictable behavior | Schema-driven, lightweight, explicit Python control |
+| **LangGraph** | Complex state management, sophisticated workflows | Graph-based execution, powerful state handling |
+| **Burr** | State machine workflows, clear decision flows | Action-based transitions, built-in UI dashboard |
+| **Pydantic-AI** | Type-safe agents with strict validation | Full Pydantic integration, FastAPI-like ergonomics |
+| **AutoGen** | Multi-agent reasoning and collaboration | Agents converse naturally to solve problems |
+| **CrewAI** | Role-based agent teams | Hierarchical agent organization with clear responsibilities |
+
+## When to Use Atomic Agents
+
+Atomic Agents excels when you need:
+
+- **Structured outputs**: Guaranteed type-safe outputs using Pydantic schemas
+- **Explicit control**: All orchestration logic written in Python (no hidden abstractions)
+- **Lightweight setup**: Minimal dependencies, easy to understand and maintain
+- **Clear contracts**: Input/output schemas define exactly what flows between components
+- **Easy chaining**: Chain agents together by aligning their schemas
+
+**Good use case**: Classification → Extraction pipelines
+
+```python
+# Step 1: Classify with confidence
+classifier = AtomicAgent[InputSchema, ClassifyOutput](...)
+result = classifier.run(user_message)
+
+# Step 2: Extract only if confident
+if result.confidence > 0.9:
+    extractor = AtomicAgent[InputSchema, ExtractOutput](...)
+    extraction = extractor.run(user_message)
+```
+
+## Comparison by Feature
+
+### Structured Outputs
+
+- **Atomic Agents**: Native support via Pydantic schemas. All outputs validated.
+- **Pydantic-AI**: Also Pydantic-based, similar validation guarantees.
+- **LangGraph**: Not primary focus, but supported through custom handling.
+- **Burr**: Supports structured outputs but not the main selling point.
+- **AutoGen**: Outputs less structured, more conversational.
+- **CrewAI**: Supports structured outputs but less emphasis than Atomic Agents.
+
+### State Management
+
+- **LangGraph**: Most sophisticated. Built-in state with reducer functions.
+- **Burr**: Clean state machine approach with snapshots.
+- **CrewAI**: Task-based state tracking across agents.
+- **Atomic Agents**: Manual state via ChatHistory and Context Providers.
+- **Pydantic-AI**: Minimal state, designed for simpler workflows.
+- **AutoGen**: State implicit in conversation history.
+
+### Orchestration (How to Route Agent Flows)
+
+- **Atomic Agents**: Explicit Python control, conditional agent chaining.
+- **LangGraph**: Graph edges with conditional routing.
+- **Burr**: Action-based transitions, explicit state updates.
+- **Pydantic-AI**: Sequential agent calls, minimal routing.
+- **AutoGen**: Automatic agent-to-agent conversation flow.
+- **CrewAI**: Task dependencies and hierarchical delegation.
+
+### Learning Curve
+
+- **Atomic Agents**: Easy - familiar Python patterns, simple API.
+- **Pydantic-AI**: Easy - familiar if you know Pydantic.
+- **Burr**: Easy - intuitive state machine concept.
+- **LangGraph**: Medium - more complex but powerful.
+- **AutoGen**: Medium - conversation concepts less familiar than traditional programming.
+- **CrewAI**: Easy - role-based metaphor is intuitive.
+
+### Community & Maturity
+
+- **LangChain ecosystem**: Largest community, most tutorials.
+- **AutoGen**: Microsoft-backed, strong research foundation.
+- **CrewAI**: Fast-growing (100k+ certified developers).
+- **Atomic Agents**: Growing community, actively maintained.
+- **Burr**: Smaller community, strong testimonials from users.
+- **Pydantic-AI**: Growing quickly, backed by Pydantic team.
+
+## Framework Profiles
+
+### Atomic Agents
+- Emphasizes modularity and explicitness
+- Schema-driven development
+- Works with any LLM provider via Instructor
+- Best for teams wanting fine-grained control
+
+### LangGraph
+- Graph-based state management
+- Excellent for complex, long-running workflows
+- LangSmith integration for observability
+- Steeper learning curve but more powerful
+
+### Burr
+- State machines with elegant API
+- Built-in UI for debugging and monitoring
+- Smaller codebase, easier to understand internals
+- Good for conversational flows
+
+### Pydantic-AI
+- Type safety as first-class concern
+- Brings FastAPI philosophy to agents
+- Good for single or simple multi-agent setups
+- Growing ecosystem
+
+### AutoGen
+- Multi-agent conversations
+- Agents reason together naturally
+- Best for complex problem-solving scenarios
+- Less suitable for rigid pipelines
+
+### CrewAI
+- Role-based agent teams
+- Task-oriented workflows
+- Creator tools for non-technical users
+- Strong production support infrastructure
+
+## Decision Guide
+
+**Use Atomic Agents if:**
+- You have clear input/output schema requirements
+- You want explicit control over agent orchestration
+- You prefer lightweight, understandable code
+- You're building classification/extraction pipelines
+- Team is comfortable with pure Python
+
+## Resources
+
+- [Atomic Agents Documentation](https://brainblend-ai.github.io/atomic-agents/)
+- [LangGraph Docs](https://docs.langchain.com/oss/python/langgraph/)
+- [Burr Docs](https://burr.apache.org/)
+- [Pydantic-AI](https://ai.pydantic.dev/)
+- [AutoGen](https://microsoft.github.io/autogen/)
+- [CrewAI](https://docs.crewai.com/)
+
+
+> Note: This comparison reflects design goals and common usage patterns, not absolute capabilities. Most frameworks can be extended beyond their typical use cases.


### PR DESCRIPTION
This PR adds a guide comparing Atomic Agents with other popular AI agent frameworks, focusing on structured outputs, state management, and orchestration tradeoffs.

Closes #140