### PR TITLE
chore: add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: [--line-length=127]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        args: [--max-line-length=127]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ atomic = "atomic_assembler.main:main"
 dev = [
     "black>=24.8.0,<25.0.0",
     "flake8>=7.1.1,<8.0.0",
+    "pre-commit>=4.0.0,<5.0.0",
     "pdoc3>=0.11.1,<1.0.0",
     "pytest>=8.3.3,<9.0.0",
     "pytest-cov>=5.0.0,<6.0.0",


### PR DESCRIPTION
## Summary
- Add missing `.pre-commit-config.yaml` file that was referenced in `docs/contributing.md` but did not exist
- Add `pre-commit` to dev dependencies in `pyproject.toml`

Fixes #204

## Configured hooks
- `trailing-whitespace` - trims trailing whitespace
- `end-of-file-fixer` - ensures files end with newline
- `check-yaml` - validates YAML syntax
- `check-added-large-files` - prevents large files from being committed
- `black` (line-length=127) - code formatting
- `flake8` (max-line-length=127) - linting

## Test plan
- [x] `uv sync` installs pre-commit
- [x] `uv run pre-commit --version` works
- [x] `uv run pre-commit run --all-files` runs all hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)