### PR TITLE
fix: guard against empty stream in run_stream to prevent UnboundLocalError

### DIFF
--- a/atomic-agents/atomic_agents/agents/atomic_agent.py
+++ b/atomic-agents/atomic_agents/agents/atomic_agent.py
@@ -481,10 +481,15 @@ class AtomicAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
             stream=True,
         )
 
+        last_response = None
         for partial_response in response_stream:
+            last_response = partial_response
             yield partial_response
 
-        full_response_content = self.output_schema(**partial_response.model_dump())
+        if last_response is None:
+            return None
+
+        full_response_content = self.output_schema(**last_response.model_dump())
         self.history.add_message(self.assistant_role, full_response_content)
         self._prepare_messages()
 


### PR DESCRIPTION
## Summary

`run_stream` references `partial_response` after the for-loop without checking if the stream yielded any items. If the response stream is empty, this causes an `UnboundLocalError` because `partial_response` was never assigned.

The async counterpart `run_async_stream` already handles this correctly by tracking `last_response = None` and checking `if last_response:` before using it. This PR applies the same guard to `run_stream`.

## What changed

- Added `last_response` tracking variable (matching `run_async_stream` pattern)
- Added `None` check before accessing the last response
- Returns `None` for empty streams instead of crashing

## Test plan

- [ ] Verify `run_stream` no longer crashes when the LLM returns an empty stream
- [ ] Verify normal streaming behavior is unchanged
- [ ] Compare behavior with `run_async_stream` which already has this guard
