### PR TITLE
fix: correct delete_turn_id parameter type annotation from int to str

### DIFF
--- a/atomic-agents/atomic_agents/context/chat_history.py
+++ b/atomic-agents/atomic_agents/context/chat_history.py
@@ -204,12 +204,12 @@ class ChatHistory:
         """
         return self.current_turn_id
 
-    def delete_turn_id(self, turn_id: int):
+    def delete_turn_id(self, turn_id: str):
         """
         Delete messages from the history by its turn ID.
 
         Args:
-            turn_id (int): The turn ID of the message to delete.
+            turn_id (str): The turn ID of the message to delete.
 
         Returns:
             str: A success message with the deleted turn ID.


### PR DESCRIPTION
## Summary

The `delete_turn_id` method in `ChatHistory` has its `turn_id` parameter typed as `int`, but turn IDs are UUID strings generated via `str(uuid.uuid4())`. The `current_turn_id` field is correctly typed as `Optional[str]`, and the method compares `turn_id` against `msg.turn_id` (which is `Optional[str]`), so the annotation is incorrect.

This causes type checkers (mypy, pyright) to report false positives and misleads callers into thinking they should pass integers.

## What changed

- Changed `turn_id: int` to `turn_id: str` in the method signature
- Updated the docstring to match

## Test plan

- [ ] Verify type checkers no longer flag calls with string turn IDs
- [ ] Existing `delete_turn_id` tests should pass unchanged
