### PR TITLE
Fix run_stream() crash on empty response stream

### DIFF
--- a/atomic-agents/atomic_agents/agents/atomic_agent.py
+++ b/atomic-agents/atomic_agents/agents/atomic_agent.py
@@ -481,14 +481,16 @@ class AtomicAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
             stream=True,
         )
 
+        last_response = None
         for partial_response in response_stream:
+            last_response = partial_response
             yield partial_response
 
-        full_response_content = self.output_schema(**partial_response.model_dump())
-        self.history.add_message(self.assistant_role, full_response_content)
-        self._prepare_messages()
-
-        return full_response_content
+        if last_response:
+            full_response_content = self.output_schema(**last_response.model_dump())
+            self.history.add_message(self.assistant_role, full_response_content)
+            self._prepare_messages()
+            return full_response_content
 
     async def run_async(self, user_input: Optional[InputSchema] = None) -> OutputSchema:
         """


### PR DESCRIPTION
## Problem

`run_stream()` uses `partial_response` directly after the for loop (line 488):

```python
for partial_response in response_stream:
    yield partial_response

full_response_content = self.output_schema(**partial_response.model_dump())
```

If the response stream yields no items, `partial_response` is never assigned and this raises `NameError`. The async counterpart `run_async_stream()` correctly handles this by tracking `last_response` and guarding with `if last_response:`.

## Fix

Align `run_stream()` with the same pattern used in `run_async_stream()`:
- Track the last response explicitly in a `last_response` variable
- Guard history update behind `if last_response:` check