### PR TITLE
fix: use max_input_tokens for context window size

### DIFF
--- a/atomic-agents/atomic_agents/utils/token_counter.py
+++ b/atomic-agents/atomic_agents/utils/token_counter.py
@@ -154,7 +154,8 @@ class TokenCounter:
         try:
             info = get_model_info(model)
             # Use max_input_tokens (context window) not max_tokens (output limit)
-            return info.get("max_input_tokens") or info.get("max_tokens")
+            max_input = info.get("max_input_tokens")
+            return max_input if max_input is not None else info.get("max_tokens")
         except Exception as e:
             logger.warning(f"Could not determine max tokens for model '{model}': {e}")
             return None

--- a/atomic-agents/tests/utils/test_token_counter.py
+++ b/atomic-agents/tests/utils/test_token_counter.py
@@ -132,6 +132,35 @@ class TestTokenCounter:
         result = counter.get_max_tokens("gpt-4")
 
         assert result == 8192
+        mock_get_model_info.assert_called_once_with("gpt-4")
+
+    @patch("litellm.get_model_info")
+    def test_get_max_tokens_falls_back_when_max_input_tokens_is_none(self, mock_get_model_info):
+        mock_get_model_info.return_value = {"max_input_tokens": None, "max_tokens": 8192}
+
+        counter = TokenCounter()
+        result = counter.get_max_tokens("gpt-4")
+
+        assert result == 8192
+
+    @patch("litellm.get_model_info")
+    def test_get_max_tokens_zero_input_tokens_returns_zero(self, mock_get_model_info):
+        """Ensure max_input_tokens=0 is not confused with 'missing'."""
+        mock_get_model_info.return_value = {"max_input_tokens": 0, "max_tokens": 4096}
+
+        counter = TokenCounter()
+        result = counter.get_max_tokens("custom-model")
+
+        assert result == 0
+
+    @patch("litellm.get_model_info")
+    def test_get_max_tokens_both_keys_missing(self, mock_get_model_info):
+        mock_get_model_info.return_value = {"model_name": "some-model"}
+
+        counter = TokenCounter()
+        result = counter.get_max_tokens("some-model")
+
+        assert result is None
 
     @patch("litellm.get_model_info")
     def test_get_max_tokens_unknown_model(self, mock_get_model_info):


### PR DESCRIPTION
## Summary
- `TokenCounter.get_max_tokens()` was using `litellm.get_max_tokens()` which returns the **output** token limit (`max_tokens`), not the **input** context window (`max_input_tokens`)
- Switched to `litellm.get_model_info()` and reading `max_input_tokens`, with fallback to `max_tokens` if unavailable
- Uses explicit `None` check (`if max_input_tokens is not None`) instead of `or` operator to correctly handle falsy values like `0`
- This fixes utilization being overstated by up to 8x for models where output limits are much smaller than context windows

## Test plan
- [x] All 29 token counter tests pass (updated mocks to use `get_model_info`)
- [x] Added test for fallback when `max_input_tokens` key is absent
- [x] Added test for fallback when `max_input_tokens` is explicitly `None`
- [x] Added test that `max_input_tokens=0` returns `0` (not fallback to `max_tokens`)
- [x] Added test for both keys missing from model info dict
- [x] Black formatting verified

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)