### PR TITLE
Use Pydantic default strictness in AtomicAgent

### DIFF
--- a/atomic-agents/atomic_agents/agents/atomic_agent.py
+++ b/atomic-agents/atomic_agents/agents/atomic_agent.py
@@ -249,6 +249,19 @@ class AtomicAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
         self.messages = self._build_system_messages()
         self.messages += self.history.get_history()
 
+    def _get_completion_kwargs(self) -> Dict[str, Any]:
+        """
+        Build kwargs for Instructor completion calls.
+
+        Instructor defaults `strict=True`, which forces enum fields to receive enum
+        instances instead of allowing Pydantic's normal coercion from strings. We
+        default to `strict=None` here so the output schema's own Pydantic behavior
+        applies unless callers explicitly override it via `model_api_parameters`.
+        """
+        completion_kwargs = dict(self.model_api_parameters)
+        completion_kwargs.setdefault("strict", None)
+        return completion_kwargs
+
     def _build_tools_definition(self) -> Optional[List[Dict[str, Any]]]:
         """
         Build the tools definition that Instructor sends for TOOLS mode.
@@ -443,7 +456,7 @@ class AtomicAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
             messages=self.messages,
             model=self.model,
             response_model=self.output_schema,
-            **self.model_api_parameters,
+            **self._get_completion_kwargs(),
         )
         self.history.add_message(self.assistant_role, response)
         self._prepare_messages()
@@ -477,7 +490,7 @@ class AtomicAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
             model=self.model,
             messages=self.messages,
             response_model=self.output_schema,
-            **self.model_api_parameters,
+            **self._get_completion_kwargs(),
             stream=True,
         )
 
@@ -515,7 +528,7 @@ class AtomicAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
         self._prepare_messages()
 
         response = await self.client.chat.completions.create(
-            model=self.model, messages=self.messages, response_model=self.output_schema, **self.model_api_parameters
+            model=self.model, messages=self.messages, response_model=self.output_schema, **self._get_completion_kwargs()
         )
 
         self.history.add_message(self.assistant_role, response)
@@ -544,7 +557,7 @@ class AtomicAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
             model=self.model,
             messages=self.messages,
             response_model=self.output_schema,
-            **self.model_api_parameters,
+            **self._get_completion_kwargs(),
             stream=True,
         )
 

--- a/atomic-agents/tests/agents/test_atomic_agent.py
+++ b/atomic-agents/tests/agents/test_atomic_agent.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import Mock, call, patch
+from enum import Enum
 from pydantic import BaseModel, Field
+from pydantic import ValidationError
 import instructor
 from atomic_agents import (
     BaseIOSchema,
@@ -146,6 +148,73 @@ def test_initialization_without_max_tokens(mock_instructor, mock_history, mock_s
     )
     agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
     assert agent.model_api_parameters["max_tokens"] == 1024
+
+
+def test_run_uses_pydantic_default_strictness_for_enum_output(mock_history, mock_system_prompt_generator):
+    class Topic(Enum):
+        FOOD = "food"
+        OTHER = "other"
+
+    class EnumOutputSchema(BaseIOSchema):
+        """Output schema with an enum field for validation tests."""
+
+        topic: Topic = Field(...)
+
+    enum_instructor = Mock(spec=instructor.Instructor)
+    enum_instructor.chat = Mock()
+    enum_instructor.chat.completions = Mock()
+
+    def mock_create(*args, **kwargs):
+        return kwargs["response_model"].model_validate({"topic": "food"}, strict=kwargs["strict"])
+
+    enum_instructor.chat.completions.create.side_effect = mock_create
+
+    config = AgentConfig(
+        client=enum_instructor,
+        model="gpt-5-mini",
+        history=mock_history,
+        system_prompt_generator=mock_system_prompt_generator,
+    )
+    agent = AtomicAgent[BasicChatInputSchema, EnumOutputSchema](config)
+
+    result = agent.run()
+
+    assert result.topic is Topic.FOOD
+    assert enum_instructor.chat.completions.create.call_args.kwargs["strict"] is None
+
+
+def test_run_respects_explicit_strict_override_for_enum_output(mock_history, mock_system_prompt_generator):
+    class Topic(Enum):
+        FOOD = "food"
+        OTHER = "other"
+
+    class EnumOutputSchema(BaseIOSchema):
+        """Output schema with an enum field for validation tests."""
+
+        topic: Topic = Field(...)
+
+    enum_instructor = Mock(spec=instructor.Instructor)
+    enum_instructor.chat = Mock()
+    enum_instructor.chat.completions = Mock()
+
+    def mock_create(*args, **kwargs):
+        return kwargs["response_model"].model_validate({"topic": "food"}, strict=kwargs["strict"])
+
+    enum_instructor.chat.completions.create.side_effect = mock_create
+
+    config = AgentConfig(
+        client=enum_instructor,
+        model="gpt-5-mini",
+        history=mock_history,
+        system_prompt_generator=mock_system_prompt_generator,
+        model_api_parameters={"strict": True},
+    )
+    agent = AtomicAgent[BasicChatInputSchema, EnumOutputSchema](config)
+
+    with pytest.raises(ValidationError):
+        agent.run()
+
+    assert enum_instructor.chat.completions.create.call_args.kwargs["strict"] is True
 
 
 def test_initialization_system_role_equals_developer(mock_instructor, mock_history, mock_system_prompt_generator):


### PR DESCRIPTION
Default AtomicAgent completion calls to `strict=None` so output schemas use normal Pydantic coercion.
This fixes enum-valued outputs that fail with `is_instance_of`.
Adds regression tests for the default behavior and explicit strict overrides.
Fixes #193