### PR TITLE
Add AG2 multi-agent orchestration example with Atomic Agents tools

### DIFF
--- a/atomic-examples/ag2-orchestration/README.md
+++ b/atomic-examples/ag2-orchestration/README.md
@@ -1,0 +1,171 @@
+# AG2 Multi-Agent Orchestration with Atomic Agents
+
+This example demonstrates framework composition: **AG2** handles multi-agent
+conversation orchestration while **Atomic Agents** provides typed,
+schema-validated tools. The two frameworks serve complementary roles — AG2
+coordinates *what* agents do; Atomic Agents ensures *how* they do it is type-safe
+and validated at runtime via Pydantic.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    AG2 Orchestration Layer                    │
+│                                                              │
+│  ┌────────────┐   task    ┌────────────────┐   findings      │
+│  │ UserProxy  │ ────────► │ ResearchAgent  │ ──────────────► │
+│  │            │           │ (calls tools)  │                 │
+│  │ detects    │           └────────┬───────┘    ┌──────────┐ │
+│  │ TERMINATE  │◄──────────────────┼────────────│ Analyst  │ │
+│  └────────────┘    TERMINATE      │            │ Agent    │ │
+│                                   │            └──────────┘ │
+└───────────────────────────────────┼─────────────────────────┘
+                                    │ bridge (typed wrappers)
+┌───────────────────────────────────▼─────────────────────────┐
+│                  Atomic Agents Tool Layer                     │
+│                                                              │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │ WebSearchTool[SearchInput, SearchOutput]            │    │
+│  │  • Pydantic validation on every call                │    │
+│  │  • Tavily / SearXNG / stub fallback                 │    │
+│  └─────────────────────────────────────────────────────┘    │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │ CalculatorTool[CalcInput, CalcOutput]               │    │
+│  │  • sympy expression evaluator                       │    │
+│  │  • Pydantic validation on every call                │    │
+│  └─────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Conversation flow
+
+1. `UserProxy` sends the task to the GroupChat.
+2. `ResearchAgent` receives the task and calls `search_web` and/or `calculate`
+   (both are Atomic Agents tools wrapped as AG2 registered functions).
+3. Each tool call validates its input schema (Pydantic), executes, validates its
+   output schema, then returns `model_dump_json()` back to the AG2 agent.
+4. `AnalystAgent` synthesizes the research into a final answer and ends the
+   conversation with `TERMINATE`.
+5. `UserProxy`'s `is_termination_msg` callback detects `TERMINATE` and cleanly
+   stops the GroupChat.
+
+### Bridge pattern
+
+Atomic Agents tools are wrapped as AG2 registered functions:
+
+```python
+@user_proxy.register_for_execution()
+@research_agent.register_for_llm(description="Search the web for information")
+def search_web(query: str, max_results: int = 5) -> str:
+    # Constructs typed Atomic Agents schema internally
+    output: SearchOutput = search_tool.run(SearchInput(query=query, max_results=max_results))
+    # Returns structured JSON string for AG2 agents to reason over
+    return output.model_dump_json()
+```
+
+This keeps the two frameworks cleanly separated:
+- **AG2** never needs to know about Pydantic schemas or Instructor.
+- **Atomic Agents** tools never need to know about AG2's messaging protocol.
+
+## Prerequisites
+
+- Python ≥ 3.12
+- `OPENAI_API_KEY` — required for AG2 agents
+
+Optional (web search):
+- `TAVILY_API_KEY` — Tavily search API key. Sign up at https://tavily.com.
+- `SEARXNG_BASE_URL` — URL of a running SearXNG instance (e.g. `http://localhost:8080`).
+
+If neither search credential is provided the example runs with a stub that
+returns representative placeholder results, so you can verify the full
+agent-conversation flow without search credentials.
+
+## Setup
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/BrainBlend-AI/atomic-agents
+   cd atomic-agents
+   ```
+
+2. Navigate to this example:
+   ```bash
+   cd atomic-examples/ag2-orchestration
+   ```
+
+3. Install dependencies:
+
+   **Using uv (recommended for this monorepo):**
+   ```bash
+   uv sync
+   ```
+
+   **Using pip:**
+   ```bash
+   pip install "atomic-agents" "ag2[openai]>=0.11.2,<1.0" sympy requests python-dotenv
+   ```
+
+4. Set environment variables. Create a `.env` file in the `ag2-orchestration`
+   directory:
+   ```env
+   OPENAI_API_KEY=sk-...
+
+   # Optional — for real web search (leave blank to use stub)
+   TAVILY_API_KEY=tvly-...
+   SEARXNG_BASE_URL=http://localhost:8080
+   ```
+
+## How to run
+
+```bash
+# From the ag2-orchestration directory:
+python main.py
+
+# Or with uv:
+uv run python main.py
+```
+
+Expected output: the GroupChat conversation prints to the console, ending when
+`AnalystAgent` says `TERMINATE`. Typically 4–6 rounds.
+
+## Key concepts
+
+### Why combine AG2 and Atomic Agents?
+
+| Concern | AG2 | Atomic Agents |
+|---|---|---|
+| Multi-agent coordination | ✅ GroupChat, speaker selection | — |
+| Termination logic | ✅ `is_termination_msg` | — |
+| Typed tool I/O | — | ✅ `BaseTool[Input, Output]` |
+| Runtime schema validation | — | ✅ Pydantic v2 |
+| Structured output | — | ✅ `BaseIOSchema` |
+| LLM provider abstraction | ✅ `LLMConfig` | ✅ Instructor |
+
+Using both frameworks together means AG2 agents receive structured, validated
+JSON from every tool call — not raw strings — which significantly reduces
+hallucination of tool results.
+
+### `BaseIOSchema`
+
+All data flowing through Atomic Agents tools inherits from `BaseIOSchema`
+(a Pydantic `BaseModel` subclass). Validation happens on construction, so
+malformed inputs fail fast with clear error messages before any API call is made.
+
+### `BaseTool[InputSchema, OutputSchema]`
+
+The generic `BaseTool` class enforces type-safe contracts between callers and
+implementations. Subclass it, implement `run()`, and the framework handles the
+rest:
+
+```python
+class WebSearchTool(BaseTool[SearchInput, SearchOutput]):
+    def run(self, params: SearchInput) -> SearchOutput:
+        ...
+```
+
+## References
+
+- [AG2 documentation](https://docs.ag2.ai)
+- [Atomic Agents documentation](https://atomicagents.ai)
+- [AG2 GroupChat guide](https://docs.ag2.ai/docs/topics/groupchat/customized_speaker_selection)
+- [Atomic Agents tools guide](https://atomicagents.ai/guides/tools)

--- a/atomic-examples/ag2-orchestration/main.py
+++ b/atomic-examples/ag2-orchestration/main.py
@@ -1,0 +1,327 @@
+"""
+AG2 Multi-Agent Orchestration with Atomic Agents Tools
+
+This example demonstrates how AG2's GroupChat orchestration layer works together
+with Atomic Agents' typed, schema-validated tools. AG2 handles multi-agent
+conversation and coordination; Atomic Agents provides the typed tool layer with
+Pydantic schema validation on every input and output.
+
+Architecture:
+    AG2 GroupChat (orchestration)
+    ├── UserProxy      — sends the initial task, detects termination
+    ├── ResearchAgent  — calls the WebSearchTool / CalculatorTool
+    └── AnalystAgent   — synthesizes findings and emits TERMINATE
+
+    Atomic Agents (typed tools)
+    ├── WebSearchTool[SearchInput, SearchOutput]  — mock HTTP search
+    └── CalculatorTool[CalcInput, CalcOutput]     — sympy evaluator
+
+Bridge pattern: each Atomic Agents tool is wrapped in a plain function that is
+registered with AG2 via @proxy.register_for_execution() /
+@agent.register_for_llm(). The function constructs the typed input schema, calls
+tool.run(), and returns model_dump_json() so AG2 agents receive structured text.
+"""
+
+import os
+from dotenv import load_dotenv
+from pydantic import Field
+from sympy import sympify
+import requests
+
+from atomic_agents import BaseTool, BaseToolConfig, BaseIOSchema
+from autogen import AssistantAgent, UserProxyAgent, GroupChat, GroupChatManager, LLMConfig
+
+load_dotenv()
+
+# ---------------------------------------------------------------------------
+# Atomic Agents — typed I/O schemas
+# ---------------------------------------------------------------------------
+
+
+class SearchInput(BaseIOSchema):
+    """Input schema for the web search tool."""
+
+    query: str = Field(..., description="Search query string")
+    max_results: int = Field(default=5, description="Maximum number of results to return")
+
+
+class SearchOutput(BaseIOSchema):
+    """Output schema for the web search tool."""
+
+    results: list[str] = Field(..., description="List of result snippets")
+    sources: list[str] = Field(default_factory=list, description="Source URLs or identifiers")
+    query_used: str = Field(..., description="The query that was executed")
+
+
+class CalcInput(BaseIOSchema):
+    """
+    Input schema for the calculator tool. Supports arithmetic, algebra,
+    exponentiation, and trigonometric expressions (e.g. 'sin(pi/2) + 2**3').
+    """
+
+    expression: str = Field(..., description="Mathematical expression to evaluate, e.g. '2 + 2' or 'sqrt(16)'")
+
+
+class CalcOutput(BaseIOSchema):
+    """Output schema for the calculator tool."""
+
+    result: str = Field(..., description="Evaluated result as a string")
+    expression_used: str = Field(..., description="The expression that was evaluated")
+
+
+# ---------------------------------------------------------------------------
+# Atomic Agents — tool configurations
+# ---------------------------------------------------------------------------
+
+
+class WebSearchConfig(BaseToolConfig):
+    """Configuration for the WebSearchTool."""
+
+    searxng_base_url: str = ""  # e.g. http://localhost:8080
+    tavily_api_key: str = ""
+    max_results: int = 5
+
+
+class CalculatorConfig(BaseToolConfig):
+    """Configuration for the CalculatorTool."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Atomic Agents — tool implementations
+# ---------------------------------------------------------------------------
+
+
+class WebSearchTool(BaseTool[SearchInput, SearchOutput]):
+    """
+    Web search tool with typed input/output schemas.
+
+    Attempts, in order:
+    1. Tavily API (if TAVILY_API_KEY is set)
+    2. SearXNG instance (if SEARXNG_BASE_URL is set)
+    3. Fallback: returns a clearly-labelled stub so the example runs
+       end-to-end without any search credentials.
+    """
+
+    input_schema = SearchInput
+    output_schema = SearchOutput
+
+    def __init__(self, config: WebSearchConfig = WebSearchConfig()):
+        super().__init__(config)
+
+    def run(self, params: SearchInput) -> SearchOutput:
+        config: WebSearchConfig = self.config  # type: ignore[assignment]
+
+        # --- Tavily ---
+        if config.tavily_api_key:
+            try:
+                resp = requests.post(
+                    "https://api.tavily.com/search",
+                    json={
+                        "api_key": config.tavily_api_key,
+                        "query": params.query,
+                        "max_results": params.max_results,
+                    },
+                    timeout=10,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                results = [r.get("content", r.get("snippet", "")) for r in data.get("results", [])]
+                sources = [r.get("url", "") for r in data.get("results", [])]
+                return SearchOutput(results=results, sources=sources, query_used=params.query)
+            except Exception as exc:
+                return SearchOutput(
+                    results=[f"Tavily search error: {exc}"],
+                    sources=[],
+                    query_used=params.query,
+                )
+
+        # --- SearXNG ---
+        if config.searxng_base_url:
+            try:
+                resp = requests.get(
+                    f"{config.searxng_base_url.rstrip('/')}/search",
+                    params={
+                        "q": params.query,
+                        "format": "json",
+                        "categories": "general",
+                    },
+                    timeout=10,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                items = data.get("results", [])[: params.max_results]
+                results = [r.get("content", r.get("title", "")) for r in items]
+                sources = [r.get("url", "") for r in items]
+                return SearchOutput(results=results, sources=sources, query_used=params.query)
+            except Exception as exc:
+                return SearchOutput(
+                    results=[f"SearXNG search error: {exc}"],
+                    sources=[],
+                    query_used=params.query,
+                )
+
+        # --- Fallback stub (no credentials configured) ---
+        stub_results = [
+            f"[Stub] Result 1 for '{params.query}': AI agent frameworks like AG2 and Atomic Agents "
+            "enable composable, schema-driven multi-agent pipelines.",
+            f"[Stub] Result 2 for '{params.query}': AG2 provides GroupChat orchestration; "
+            "Atomic Agents provides typed, Pydantic-validated tools.",
+            f"[Stub] Result 3 for '{params.query}': The combination allows structured data flow "
+            "between agents with runtime validation on every tool call.",
+        ]
+        return SearchOutput(
+            results=stub_results[: params.max_results],
+            sources=["https://docs.ag2.ai", "https://atomicagents.ai"],
+            query_used=params.query,
+        )
+
+
+class CalculatorTool(BaseTool[CalcInput, CalcOutput]):
+    """
+    Calculator tool backed by sympy. Evaluates arithmetic and algebraic
+    expressions with full type-safe input/output schemas.
+    """
+
+    input_schema = CalcInput
+    output_schema = CalcOutput
+
+    def __init__(self, config: CalculatorConfig = CalculatorConfig()):
+        super().__init__(config)
+
+    def run(self, params: CalcInput) -> CalcOutput:
+        try:
+            parsed = sympify(params.expression)
+            result = str(parsed.evalf())
+        except Exception as exc:
+            result = f"Error evaluating expression: {exc}"
+        return CalcOutput(result=result, expression_used=params.expression)
+
+
+# ---------------------------------------------------------------------------
+# Tool instantiation (reads env vars for optional credentials)
+# ---------------------------------------------------------------------------
+
+search_tool = WebSearchTool(
+    config=WebSearchConfig(
+        tavily_api_key=os.getenv("TAVILY_API_KEY", ""),
+        searxng_base_url=os.getenv("SEARXNG_BASE_URL", ""),
+        max_results=5,
+    )
+)
+
+calculator_tool = CalculatorTool()
+
+# ---------------------------------------------------------------------------
+# AG2 setup
+# ---------------------------------------------------------------------------
+
+llm_config = LLMConfig(
+    {
+        "model": "gpt-4o-mini",
+        "api_key": os.getenv("OPENAI_API_KEY"),
+        "api_type": "openai",
+    }
+)
+
+
+def is_termination_msg(message: dict) -> bool:
+    """Detect TERMINATE signal from analyst agent."""
+    content = message.get("content", "") or ""
+    return "TERMINATE" in content
+
+
+user_proxy = UserProxyAgent(
+    name="user_proxy",
+    human_input_mode="NEVER",
+    max_consecutive_auto_reply=10,
+    code_execution_config=False,
+    is_termination_msg=is_termination_msg,
+)
+
+research_agent = AssistantAgent(
+    name="research_agent",
+    system_message=(
+        "You are a research agent. Use the available tools to gather information.\n"
+        "- Use search_web to look up topics and current information.\n"
+        "- Use calculate to evaluate any numerical or mathematical expressions.\n"
+        "Be thorough but concise. Pass your findings to the analyst agent."
+    ),
+    llm_config=llm_config,
+)
+
+analyst_agent = AssistantAgent(
+    name="analyst_agent",
+    system_message=(
+        "You are an analyst agent. Synthesize research findings into a clear, "
+        "well-structured answer. After providing your final answer, "
+        "end your message with the word TERMINATE on its own line."
+    ),
+    llm_config=llm_config,
+)
+
+# ---------------------------------------------------------------------------
+# Bridge: wrap Atomic Agents tools as AG2 registered functions
+# Each function accepts plain Python types (AG2 handles schema generation),
+# constructs the typed Atomic Agents input schema internally, and returns
+# model_dump_json() so AG2 agents receive structured, readable output.
+# ---------------------------------------------------------------------------
+
+
+@user_proxy.register_for_execution()
+@research_agent.register_for_llm(description="Search the web for information on a topic. Returns structured results.")
+def search_web(query: str, max_results: int = 5) -> str:
+    """AG2-registered wrapper around WebSearchTool."""
+    output: SearchOutput = search_tool.run(SearchInput(query=query, max_results=max_results))
+    return output.model_dump_json()
+
+
+@user_proxy.register_for_execution()
+@research_agent.register_for_llm(description="Evaluate a mathematical or algebraic expression using sympy.")
+def calculate(expression: str) -> str:
+    """AG2-registered wrapper around CalculatorTool."""
+    output: CalcOutput = calculator_tool.run(CalcInput(expression=expression))
+    return output.model_dump_json()
+
+
+# ---------------------------------------------------------------------------
+# GroupChat orchestration
+# ---------------------------------------------------------------------------
+
+group_chat = GroupChat(
+    agents=[user_proxy, research_agent, analyst_agent],
+    messages=[],
+    max_round=12,
+)
+
+manager = GroupChatManager(
+    groupchat=group_chat,
+    llm_config=llm_config,
+    is_termination_msg=is_termination_msg,
+)
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    task = (
+        "Research and compare the top 3 AI agent frameworks in 2026. "
+        "For each framework, describe its key design philosophy and primary use case. "
+        "Also calculate how many months have passed since January 2024."
+    )
+
+    print("=" * 72)
+    print("AG2 Multi-Agent Orchestration with Atomic Agents Tools")
+    print("=" * 72)
+    print(f"Task: {task}\n")
+
+    result = user_proxy.run(manager, message=task)
+    result.process()
+
+    print("\n" + "=" * 72)
+    print("Conversation complete.")
+    if result.summary:
+        print(f"\nSummary:\n{result.summary}")
+    print("=" * 72)

--- a/atomic-examples/ag2-orchestration/pyproject.toml
+++ b/atomic-examples/ag2-orchestration/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ag2_orchestration"]
+
+[project]
+name = "ag2-orchestration"
+version = "0.1.0"
+description = "AG2 multi-agent orchestration example using Atomic Agents typed tools"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "atomic-agents",
+    "ag2[openai]>=0.11.2,<1.0",
+    "sympy>=1.13.0,<2.0.0",
+    "requests>=2.32.0,<3.0.0",
+    "python-dotenv>=1.0.1,<2.0.0",
+]
+
+[tool.uv.sources]
+atomic-agents = { workspace = true }


### PR DESCRIPTION
Adds a new example under atomic-examples/ag2-orchestration/ demonstrating framework composition: AG2 GroupChat orchestrates a multi-agent conversation while Atomic Agents provides typed, schema-validated tools via BaseTool.

Architecture:
- UserProxy sends the initial task and detects TERMINATE
- ResearchAgent calls search_web / calculate (Atomic Agents tool wrappers)
- AnalystAgent synthesizes findings and emits TERMINATE
- WebSearchTool[SearchInput, SearchOutput]: Tavily / SearXNG / stub fallback
- CalculatorTool[CalcInput, CalcOutput]: sympy expression evaluator

Bridge pattern: each Atomic Agents tool is wrapped in a plain Python function registered with AG2 via @proxy.register_for_execution() / @agent.register_for_llm(). The wrapper constructs the typed input schema, calls tool.run(), and returns model_dump_json() so AG2 agents receive structured JSON with Pydantic validation on every call.

E2E validated: 4-round conversation, terminated via TERMINATE (not max_round), both tools called with real Tavily search + sympy calculator.

Files added:
- atomic-examples/ag2-orchestration/main.py
- atomic-examples/ag2-orchestration/README.md
- atomic-examples/ag2-orchestration/pyproject.toml

Dependencies: atomic-agents, ag2[openai]>=0.11.2, sympy, requests, python-dotenv
Requires: OPENAI_API_KEY (optional: TAVILY_API_KEY or SEARXNG_BASE_URL)