### PR TITLE
feat: add BaseSystemPromptGenerator class

### DIFF
--- a/atomic-agents/atomic_agents/agents/atomic_agent.py
+++ b/atomic-agents/atomic_agents/agents/atomic_agent.py
@@ -8,6 +8,7 @@ from atomic_agents.context.chat_history import ChatHistory
 from atomic_agents.context.system_prompt_generator import (
     BaseDynamicContextProvider,
     SystemPromptGenerator,
+    BaseSystemPromptGenerator,
 )
 from atomic_agents.base.base_io_schema import BaseIOSchema
 from atomic_agents.utils.token_counter import get_token_counter, TokenCountResult
@@ -66,7 +67,7 @@ class AgentConfig(BaseModel):
     client: instructor.core.client.Instructor = Field(..., description="Client for interacting with the language model.")
     model: str = Field(default="gpt-5-mini", description="The model to use for generating responses.")
     history: Optional[ChatHistory] = Field(default=None, description="History component for storing chat history.")
-    system_prompt_generator: Optional[SystemPromptGenerator] = Field(
+    system_prompt_generator: Optional[BaseSystemPromptGenerator] = Field(
         default=None, description="Component for generating system prompts."
     )
     system_role: Optional[str] = Field(

--- a/atomic-agents/atomic_agents/agents/atomic_agent.py
+++ b/atomic-agents/atomic_agents/agents/atomic_agent.py
@@ -68,10 +68,11 @@ class AgentConfig(BaseModel):
     model: str = Field(default="gpt-5-mini", description="The model to use for generating responses.")
     history: Optional[ChatHistory] = Field(default=None, description="History component for storing chat history.")
     system_prompt_generator: Optional[BaseSystemPromptGenerator] = Field(
-        default=None, description=(
+        default=None,
+        description=(
             "Component for generating system prompts. "
             "Defaults to SystemPromptGenerator if no subclass of BaseSystemPromptGenerator is passed."
-        )
+        ),
     )
     system_role: Optional[str] = Field(
         default="system", description="The role of the system in the conversation. None means no system prompt."

--- a/atomic-agents/atomic_agents/agents/atomic_agent.py
+++ b/atomic-agents/atomic_agents/agents/atomic_agent.py
@@ -68,7 +68,10 @@ class AgentConfig(BaseModel):
     model: str = Field(default="gpt-5-mini", description="The model to use for generating responses.")
     history: Optional[ChatHistory] = Field(default=None, description="History component for storing chat history.")
     system_prompt_generator: Optional[BaseSystemPromptGenerator] = Field(
-        default=None, description="Component for generating system prompts."
+        default=None, description=(
+            "Component for generating system prompts. "
+            "Defaults to SystemPromptGenerator if no subclass of BaseSystemPromptGenerator is passed."
+        )
     )
     system_role: Optional[str] = Field(
         default="system", description="The role of the system in the conversation. None means no system prompt."
@@ -114,7 +117,7 @@ class AtomicAgent[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema]:
         client: Client for interacting with the language model.
         model (str): The model to use for generating responses.
         history (ChatHistory): History component for storing chat history.
-        system_prompt_generator (SystemPromptGenerator): Component for generating system prompts.
+        system_prompt_generator (BaseSystemPromptGenerator): Component for generating system prompts.
         system_role (Optional[str]): The role of the system in the conversation. None means no system prompt.
         assistant_role (str): The role of the assistant in the conversation. Use 'model' for Gemini, 'assistant' for OpenAI/Anthropic.
         initial_history (ChatHistory): Initial state of the history.

--- a/atomic-agents/atomic_agents/context/__init__.py
+++ b/atomic-agents/atomic_agents/context/__init__.py
@@ -2,6 +2,7 @@ from .chat_history import Message, ChatHistory
 from .system_prompt_generator import (
     BaseDynamicContextProvider,
     SystemPromptGenerator,
+    BaseSystemPromptGenerator,
 )
 
 __all__ = [
@@ -9,4 +10,5 @@ __all__ = [
     "ChatHistory",
     "SystemPromptGenerator",
     "BaseDynamicContextProvider",
+    "BaseSystemPromptGenerator",
 ]

--- a/atomic-agents/atomic_agents/context/system_prompt_generator.py
+++ b/atomic-agents/atomic_agents/context/system_prompt_generator.py
@@ -23,9 +23,7 @@ class BaseSystemPromptGenerator(ABC):
         pass
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__} (providers={list(self.context_providers)})"
-        )
+        return f"{self.__class__.__name__} (providers={list(self.context_providers)})"
 
 
 class SystemPromptGenerator(BaseSystemPromptGenerator):

--- a/atomic-agents/atomic_agents/context/system_prompt_generator.py
+++ b/atomic-agents/atomic_agents/context/system_prompt_generator.py
@@ -12,9 +12,24 @@ class BaseDynamicContextProvider(ABC):
 
     def __repr__(self) -> str:
         return self.get_info()
+    
+
+class BaseSystemPromptGenerator(ABC):
+    def __init__(
+            self,
+            context_providers: Optional[Dict[str, BaseDynamicContextProvider]] = None
+    ):
+        self.context_providers = context_providers or {}
+
+    @abstractmethod
+    def generate_prompt(self) -> str:
+        pass
+
+    def __repr__(self) -> str:
+        return self.generate_prompt()
 
 
-class SystemPromptGenerator:
+class SystemPromptGenerator(BaseSystemPromptGenerator):
     def __init__(
         self,
         background: Optional[List[str]] = None,
@@ -22,10 +37,10 @@ class SystemPromptGenerator:
         output_instructions: Optional[List[str]] = None,
         context_providers: Optional[Dict[str, BaseDynamicContextProvider]] = None,
     ):
+        super().__init__(context_providers=context_providers)
         self.background = background or ["This is a conversation with a helpful and friendly AI assistant."]
         self.steps = steps or []
         self.output_instructions = output_instructions or []
-        self.context_providers = context_providers or {}
 
         self.output_instructions.extend(
             [

--- a/atomic-agents/atomic_agents/context/system_prompt_generator.py
+++ b/atomic-agents/atomic_agents/context/system_prompt_generator.py
@@ -23,7 +23,9 @@ class BaseSystemPromptGenerator(ABC):
         pass
 
     def __repr__(self) -> str:
-        return self.generate_prompt()
+        return (
+            f"{self.__class__.__name__} (providers={list(self.context_providers)})"
+        )
 
 
 class SystemPromptGenerator(BaseSystemPromptGenerator):

--- a/atomic-agents/atomic_agents/context/system_prompt_generator.py
+++ b/atomic-agents/atomic_agents/context/system_prompt_generator.py
@@ -12,13 +12,10 @@ class BaseDynamicContextProvider(ABC):
 
     def __repr__(self) -> str:
         return self.get_info()
-    
+
 
 class BaseSystemPromptGenerator(ABC):
-    def __init__(
-            self,
-            context_providers: Optional[Dict[str, BaseDynamicContextProvider]] = None
-    ):
+    def __init__(self, context_providers: Optional[Dict[str, BaseDynamicContextProvider]] = None):
         self.context_providers = context_providers or {}
 
     @abstractmethod

--- a/atomic-agents/tests/agents/test_atomic_agent.py
+++ b/atomic-agents/tests/agents/test_atomic_agent.py
@@ -12,8 +12,8 @@ from atomic_agents import (
     BasicChatOutputSchema,
 )
 from atomic_agents.context import (
-    ChatHistory, 
-    SystemPromptGenerator, 
+    ChatHistory,
+    SystemPromptGenerator,
     BaseDynamicContextProvider,
     BaseSystemPromptGenerator,
 )
@@ -1396,17 +1396,20 @@ def test_trim_context_called_before_user_message_in_run(mock_get_token_counter, 
 # --- Test BaseSystemPromptGenerator integration ---
 
 
-def test_custom_system_prompt_generator_reaches_agent(mock_instructor, mock_custom_system_prompt_generator, mock_context_provider):
-        
-        agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](
-            AgentConfig(
-                client=mock_instructor,
-                model="gpt-5-mini",
-                system_prompt_generator=mock_custom_system_prompt_generator,
-            ))
+def test_custom_system_prompt_generator_reaches_agent(
+    mock_instructor, mock_custom_system_prompt_generator, mock_context_provider
+):
 
-        agent.register_context_provider("test_provider", mock_context_provider)
+    agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](
+        AgentConfig(
+            client=mock_instructor,
+            model="gpt-5-mini",
+            system_prompt_generator=mock_custom_system_prompt_generator,
+        )
+    )
 
-        assert agent.system_prompt_generator == mock_custom_system_prompt_generator
-        assert agent._build_system_messages() == [{'content': "Custom Prompt", 'role': 'system'}]
-        assert agent.system_prompt_generator.context_providers == {'test_provider': mock_context_provider}
+    agent.register_context_provider("test_provider", mock_context_provider)
+
+    assert agent.system_prompt_generator == mock_custom_system_prompt_generator
+    assert agent._build_system_messages() == [{"content": "Custom Prompt", "role": "system"}]
+    assert agent.system_prompt_generator.context_providers == {"test_provider": mock_context_provider}

--- a/atomic-agents/tests/agents/test_atomic_agent.py
+++ b/atomic-agents/tests/agents/test_atomic_agent.py
@@ -11,7 +11,12 @@ from atomic_agents import (
     BasicChatInputSchema,
     BasicChatOutputSchema,
 )
-from atomic_agents.context import ChatHistory, SystemPromptGenerator, BaseDynamicContextProvider
+from atomic_agents.context import (
+    ChatHistory, 
+    SystemPromptGenerator, 
+    BaseDynamicContextProvider,
+    BaseSystemPromptGenerator,
+)
 from atomic_agents.utils.token_counter import TokenCountResult
 from instructor.dsl.partial import PartialBase
 
@@ -103,6 +108,32 @@ def agent_config_async(mock_instructor_async, mock_history, mock_system_prompt_g
 @pytest.fixture
 def agent_async(agent_config_async):
     return AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](agent_config_async)
+
+
+@pytest.fixture
+def mock_custom_system_prompt_generator():
+    class MockSystemPromptGenerator(BaseSystemPromptGenerator):
+        def __init__(self, context_providers=None, system_prompt=""):
+            super().__init__(context_providers=context_providers)
+            self.system_prompt = system_prompt
+
+        def generate_prompt(self) -> str:
+            return self.system_prompt
+
+    return MockSystemPromptGenerator(system_prompt="Custom Prompt")
+
+
+@pytest.fixture
+def mock_context_provider():
+    class MockContextProvider(BaseDynamicContextProvider):
+        def __init__(self, title: str, info: str):
+            super().__init__(title)
+            self._info = info
+
+        def get_info(self) -> str:
+            return self._info
+
+    return MockContextProvider(title="Mock Provider", info="Test")
 
 
 def test_initialization(agent, mock_instructor, mock_history, mock_system_prompt_generator):
@@ -1360,3 +1391,22 @@ def test_trim_context_called_before_user_message_in_run(mock_get_token_counter, 
     # Old turn was trimmed BEFORE new message was added
     assert history.get_message_count() == 2  # assistant response + new user message
     assert history.history[0].content.chat_message == "New message"  # new message is first
+
+
+# --- Test BaseSystemPromptGenerator integration ---
+
+
+def test_custom_system_prompt_generator_reaches_agent(mock_instructor, mock_custom_system_prompt_generator, mock_context_provider):
+        
+        agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](
+            AgentConfig(
+                client=mock_instructor,
+                model="gpt-5-mini",
+                system_prompt_generator=mock_custom_system_prompt_generator,
+            ))
+
+        agent.register_context_provider("test_provider", mock_context_provider)
+
+        assert agent.system_prompt_generator == mock_custom_system_prompt_generator
+        assert agent._build_system_messages() == [{'content': "Custom Prompt", 'role': 'system'}]
+        assert agent.system_prompt_generator.context_providers == {'test_provider': mock_context_provider}

--- a/atomic-agents/tests/context/test_system_prompt_generator.py
+++ b/atomic-agents/tests/context/test_system_prompt_generator.py
@@ -16,14 +16,10 @@ class MockContextProvider(BaseDynamicContextProvider):
 
     def get_info(self) -> str:
         return self._info
-    
+
 
 class MockSystemPromptGenerator(BaseSystemPromptGenerator):
-    def __init__(
-        self, 
-        system_prompt: str, 
-        context_providers: Optional[Dict[str, BaseDynamicContextProvider]]=None
-    ):
+    def __init__(self, system_prompt: str, context_providers: Optional[Dict[str, BaseDynamicContextProvider]] = None):
         super().__init__(context_providers)
         self.system_prompt = system_prompt
 
@@ -154,8 +150,7 @@ def test_generate_prompt_with_empty_context_provider():
 def test_base_system_prompt_generator_repr():
     mock_context_provider = MockContextProvider("Mock Provider", "Test")
     mock_generator = MockSystemPromptGenerator(
-        context_providers={'mock_provider': mock_context_provider},
-        system_prompt='Test prompt'
+        context_providers={"mock_provider": mock_context_provider}, system_prompt="Test prompt"
     )
 
     assert repr(mock_generator) == "MockSystemPromptGenerator (providers=['mock_provider'])"
@@ -164,12 +159,11 @@ def test_base_system_prompt_generator_repr():
 def test_custom_system_prompt_generator():
     mock_context_provider = MockContextProvider("Mock Provider", "Test")
     mock_generator = MockSystemPromptGenerator(
-        context_providers={'mock_provider': mock_context_provider},
-        system_prompt='Test prompt'
+        context_providers={"mock_provider": mock_context_provider}, system_prompt="Test prompt"
     )
 
-    assert mock_generator.context_providers == {'mock_provider': mock_context_provider}
-    assert mock_generator.system_prompt == 'Test prompt'
+    assert mock_generator.context_providers == {"mock_provider": mock_context_provider}
+    assert mock_generator.system_prompt == "Test prompt"
 
 
 def test_system_prompt_generator_with_no_generate_prompt():

--- a/atomic-agents/tests/context/test_system_prompt_generator.py
+++ b/atomic-agents/tests/context/test_system_prompt_generator.py
@@ -1,3 +1,7 @@
+from typing import Dict, Optional
+
+import pytest
+
 from atomic_agents.context import (
     SystemPromptGenerator,
     BaseDynamicContextProvider,
@@ -12,6 +16,19 @@ class MockContextProvider(BaseDynamicContextProvider):
 
     def get_info(self) -> str:
         return self._info
+    
+
+class MockSystemPromptGenerator(BaseSystemPromptGenerator):
+    def __init__(
+        self, 
+        system_prompt: str, 
+        context_providers: Optional[Dict[str, BaseDynamicContextProvider]]=None
+    ):
+        super().__init__(context_providers)
+        self.system_prompt = system_prompt
+
+    def generate_prompt(self):
+        return self.system_prompt
 
 
 def test_system_prompt_generator_default_initialization():
@@ -135,9 +152,32 @@ def test_generate_prompt_with_empty_context_provider():
 
 
 def test_base_system_prompt_generator_repr():
-    class Impl(BaseSystemPromptGenerator):
-        def generate_prompt(self) -> str:
-            return "X"
+    mock_context_provider = MockContextProvider("Mock Provider", "Test")
+    mock_generator = MockSystemPromptGenerator(
+        context_providers={'mock_provider': mock_context_provider},
+        system_prompt='Test prompt'
+    )
 
-    impl = Impl()
-    assert repr(impl) == "X"
+    assert repr(mock_generator) == "MockSystemPromptGenerator (providers=['mock_provider'])"
+
+
+def test_custom_system_prompt_generator():
+    mock_context_provider = MockContextProvider("Mock Provider", "Test")
+    mock_generator = MockSystemPromptGenerator(
+        context_providers={'mock_provider': mock_context_provider},
+        system_prompt='Test prompt'
+    )
+
+    assert mock_generator.context_providers == {'mock_provider': mock_context_provider}
+    assert mock_generator.system_prompt == 'Test prompt'
+
+
+def test_system_prompt_generator_with_no_generate_prompt():
+    with pytest.raises(TypeError):
+        BaseSystemPromptGenerator()
+
+
+def test_base_system_prompt_generator_with_no_context_providers():
+    generator = MockSystemPromptGenerator(system_prompt="Test prompt")
+    assert generator.context_providers == {}
+    assert repr(generator) == "MockSystemPromptGenerator (providers=[])"

--- a/atomic-agents/tests/context/test_system_prompt_generator.py
+++ b/atomic-agents/tests/context/test_system_prompt_generator.py
@@ -1,4 +1,8 @@
-from atomic_agents.context import SystemPromptGenerator, BaseDynamicContextProvider
+from atomic_agents.context import (
+    SystemPromptGenerator, 
+    BaseDynamicContextProvider,
+    BaseSystemPromptGenerator,
+)
 
 
 class MockContextProvider(BaseDynamicContextProvider):
@@ -128,3 +132,11 @@ def test_generate_prompt_with_empty_context_provider():
 # EXTRA INFORMATION AND CONTEXT"""
 
     assert generator.generate_prompt() == expected_prompt
+
+def test_base_system_prompt_generator_repr():
+    class Impl(BaseSystemPromptGenerator):
+        def generate_prompt(self) -> str:
+            return "X"
+
+    impl = Impl()
+    assert repr(impl) == "X"

--- a/atomic-agents/tests/context/test_system_prompt_generator.py
+++ b/atomic-agents/tests/context/test_system_prompt_generator.py
@@ -1,5 +1,5 @@
 from atomic_agents.context import (
-    SystemPromptGenerator, 
+    SystemPromptGenerator,
     BaseDynamicContextProvider,
     BaseSystemPromptGenerator,
 )
@@ -132,6 +132,7 @@ def test_generate_prompt_with_empty_context_provider():
 # EXTRA INFORMATION AND CONTEXT"""
 
     assert generator.generate_prompt() == expected_prompt
+
 
 def test_base_system_prompt_generator_repr():
     class Impl(BaseSystemPromptGenerator):

--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -104,6 +104,54 @@ generator = SystemPromptGenerator(
 prompt = generator.generate_prompt()
 ```
 
+### Custom System Prompt Generator
+
+If you prefer to have more control over the system prompt generator you can create a custom system prompt generator by inheriting from `BaseSystemPromptGenerator`:
+
+```python
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+from atomic_agents.context import BaseDynamicContextProvider, BaseSystemPromptGenerator
+
+
+# Define custom generator class
+class MarkdownFileSystemPromptGenerator(BaseSystemPromptGenerator):
+
+    def __init__(
+        self,
+        md_file: Union[Path, str],
+        context_providers: Optional[Dict[str, BaseDynamicContextProvider]] = None,
+    ):
+        super().__init__(context_providers=context_providers)
+
+        path = Path(md_file)
+        if not path.exists():
+            raise FileNotFoundError(f"System prompt file not found: {md_file}")
+
+        self.system_prompt = path.read_text(encoding="utf-8")
+
+    def generate_prompt(self) -> str:
+        prompt_parts = [self.system_prompt]
+
+        if self.context_providers:
+            prompt_parts.append("# EXTRA INFORMATION AND CONTEXT")
+            for provider in self.context_providers.values():
+                info = provider.get_info()
+                if info:
+                    prompt_parts.append(f"## {provider.title}")
+                    prompt_parts.append(info)
+                    prompt_parts.append("")
+
+        return "\n".join(prompt_parts).strip()
+
+# Create generator
+generator = MarkdownFileSystemPromptGenerator("path/to/system_prompt.md")
+
+# Generate prompt
+prompt = generator.generate_prompt()
+```
+
 ### Dynamic Context Providers
 
 Context providers inject dynamic information into prompts:

--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -106,18 +106,19 @@ prompt = generator.generate_prompt()
 
 ### Custom System Prompt Generator
 
-If you prefer to have more control over the system prompt generator you can create a custom system prompt generator by inheriting from `BaseSystemPromptGenerator`:
+If you require finer control over system prompt construction, subclass `BaseSystemPromptGenerator` and implement `generate_prompt()`. This approach is useful when prompt content should be maintained in a human-readable format (e.g., Markdown or text file) to allow review or editing by non-developers.
 
 ```python
 from pathlib import Path
 from typing import Dict, Optional, Union
 
-from atomic_agents.context import BaseDynamicContextProvider, BaseSystemPromptGenerator
+from atomic_agents.context import (
+    BaseDynamicContextProvider, 
+    BaseSystemPromptGenerator
+)
 
 
-# Define custom generator class
 class MarkdownFileSystemPromptGenerator(BaseSystemPromptGenerator):
-
     def __init__(
         self,
         md_file: Union[Path, str],
@@ -132,23 +133,22 @@ class MarkdownFileSystemPromptGenerator(BaseSystemPromptGenerator):
         self.system_prompt = path.read_text(encoding="utf-8")
 
     def generate_prompt(self) -> str:
-        prompt_parts = [self.system_prompt]
+        return f"{self.system_prompt}\n\n{self._build_context_string()}"
 
-        if self.context_providers:
-            prompt_parts.append("# EXTRA INFORMATION AND CONTEXT")
-            for provider in self.context_providers.values():
-                info = provider.get_info()
-                if info:
-                    prompt_parts.append(f"## {provider.title}")
-                    prompt_parts.append(info)
-                    prompt_parts.append("")
+    def _build_context_string(self) -> str:
+        if not self.context_providers:
+            return ""
 
-        return "\n".join(prompt_parts).strip()
+        context_sections = ["# Additional Context"]
+        for provider in self.context_providers.values():
+            info = provider.get_info()
+            if info:
+                context_sections.append(f"## {provider.title}")
+                context_sections.append(info)
+                context_sections.append("")
+        return "\n".join(context_sections).strip()
 
-# Create generator
 generator = MarkdownFileSystemPromptGenerator("path/to/system_prompt.md")
-
-# Generate prompt
 prompt = generator.generate_prompt()
 ```
 


### PR DESCRIPTION
- Add BaseSystemPromptGenerator to provide an extensible base for custom system prompt generators

- Add unit test covering the new base class (__repr__). All tests pass.

- Update docs/api/context.md with an example showing how to implement and use a custom generator.