### PR TITLE
docs(claude-plugin): recommend BrainBlend marketplace as primary install

### DIFF
--- a/claude-plugin/atomic-agents/README.md
+++ b/claude-plugin/atomic-agents/README.md
@@ -15,13 +15,43 @@ This follows the hybrid pattern Anthropic themselves ship: reference skills for 
 
 ## Install
 
-### Claude Code marketplace
+### Recommended — from the BrainBlend marketplace
 
 ```
-/plugin install atomic-agents@<marketplace-name>
+/plugin marketplace add BrainBlend-AI/atomic-agents
+/plugin install atomic-agents@brainblend-plugins
 ```
 
-### Local
+This path gets you the latest version immediately. We control the marketplace, so pushes to `main` in this repo reach users on the next `/plugin marketplace update` (and auto-update is on by default for git-hosted marketplaces you've explicitly added).
+
+### From the official Anthropic marketplace
+
+```
+/plugin install atomic-agents@claude-plugins-official
+```
+
+> **Note (April 2026)**: The entry in the official marketplace currently uses a source type that silently drops the plugin's subdirectory `path`, causing the plugin to load empty (zero agents, zero skills). Tracking fix at [anthropics/claude-plugins-official#1436](https://github.com/anthropics/claude-plugins-official/issues/1436). Until that's applied, use the BrainBlend marketplace above.
+
+### Team projects (declarative)
+
+To require this plugin for everyone who opens a given repo, add it to the project's `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "brainblend-plugins": {
+      "source": { "source": "github", "repo": "BrainBlend-AI/atomic-agents" }
+    }
+  },
+  "enabledPlugins": {
+    "atomic-agents@brainblend-plugins": true
+  }
+}
+```
+
+Claude Code prompts each teammate to install on first trust of the folder.
+
+### Local dev
 
 ```bash
 claude --plugin-dir /path/to/atomic-agents/claude-plugin/atomic-agents


### PR DESCRIPTION
## Summary

- Recommend installing the Claude Code plugin from **our own marketplace** first (`/plugin marketplace add BrainBlend-AI/atomic-agents` → `/plugin install atomic-agents@brainblend-plugins`) because the entry in `claude-plugins-official` loads empty (`source: url` silently drops the `path` field; plugin registers zero agents and zero skills).
- Keep the official-marketplace install with a dated disclaimer linking to [anthropics/claude-plugins-official#1436](https://github.com/anthropics/claude-plugins-official/issues/1436) where the fix is tracked.
- Add a `.claude/settings.json` snippet for teams to declaratively install the plugin across collaborators via `extraKnownMarketplaces` + `enabledPlugins`.

## Why

Our marketplace.json uses `"source": "./claude-plugin/atomic-agents"` — the relative-path form that the docs document as working for git-hosted marketplaces. The claude-plugins-official entry uses `source: "url"` with a `path` field (the only such entry in that marketplace, added in Dec 2025 before `git-subdir` existed), which isn't in the official schema for `url` sources and is dropped at install. Empirically verified: cache contains the whole repo at the install root instead of the `claude-plugin/atomic-agents/` subdirectory; `/reload-plugins` + `/agents` show zero components loaded for this plugin.

## Test plan

- [ ] `/plugin marketplace add BrainBlend-AI/atomic-agents` resolves
- [ ] `/plugin install atomic-agents@brainblend-plugins` installs v2.0.0
- [ ] `/reload-plugins` followed by `/agents` lists `atomic-agents:atomic-explorer` and `atomic-agents:atomic-reviewer`
- [ ] `/atomic` autocomplete surfaces the `new-app` skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)