### PR TITLE
feat: add Manifest as an LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ uv sync --all-packages
 
 ## Provider & Model Compatibility
 
-Atomic Agents depends on the [Instructor](https://github.com/jxnl/instructor) package. This means that in all examples where OpenAI is used, any other API supported by Instructor can also be used—such as Ollama, Groq, Mistral, Cohere, Anthropic, Gemini, [MiniMax](https://www.minimax.io/), and more. For a complete list, please refer to the Instructor documentation on its [GitHub page](https://github.com/jxnl/instructor).
+Atomic Agents depends on the [Instructor](https://github.com/jxnl/instructor) package. This means that in all examples where OpenAI is used, any other API supported by Instructor can also be used—such as Ollama, Groq, Mistral, Cohere, Anthropic, Gemini, [MiniMax](https://www.minimax.io/), [Manifest](https://manifest.build/), and more. For a complete list, please refer to the Instructor documentation on its [GitHub page](https://github.com/jxnl/instructor).
 
 ## Contributing
 

--- a/atomic-agents/tests/agents/test_manifest_provider.py
+++ b/atomic-agents/tests/agents/test_manifest_provider.py
@@ -1,0 +1,183 @@
+"""Unit tests for Manifest provider integration with Atomic Agents."""
+
+import os
+import pytest
+from unittest.mock import Mock, patch
+import instructor
+from atomic_agents import (
+    AtomicAgent,
+    AgentConfig,
+    BasicChatInputSchema,
+    BasicChatOutputSchema,
+)
+from atomic_agents.context import SystemPromptGenerator
+
+
+def _create_manifest_client(api_key="test-key", base_url="https://app.manifest.build/v1"):
+    """Create a Manifest client via OpenAI-compatible interface."""
+    from openai import OpenAI
+
+    return instructor.from_openai(OpenAI(base_url=base_url, api_key=api_key))
+
+
+class TestManifestClientSetup:
+    """Tests for Manifest client initialization."""
+
+    def test_manifest_client_creation(self):
+        """Test that Manifest client can be created with correct base_url."""
+        from openai import OpenAI
+
+        raw_client = OpenAI(base_url="https://app.manifest.build/v1", api_key="test-key")
+        assert raw_client.base_url == "https://app.manifest.build/v1/"
+
+    def test_manifest_instructor_wrapping(self):
+        """Test that Manifest client can be wrapped with instructor."""
+        client = _create_manifest_client()
+        assert isinstance(client, instructor.Instructor)
+
+    def test_manifest_agent_config(self):
+        """Test that AgentConfig accepts Manifest client and model."""
+        client = _create_manifest_client()
+        config = AgentConfig(
+            client=client,
+            model="auto",
+        )
+        assert config.model == "auto"
+        assert config.assistant_role == "assistant"
+
+    def test_manifest_agent_initialization(self):
+        """Test that AtomicAgent can be initialized with Manifest config."""
+        client = _create_manifest_client()
+        config = AgentConfig(
+            client=client,
+            model="auto",
+        )
+        agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
+        assert agent.model == "auto"
+        assert agent.assistant_role == "assistant"
+
+    def test_manifest_self_hosted_url(self):
+        """Test that self-hosted Manifest URL works."""
+        client = _create_manifest_client(base_url="http://localhost:3001/v1")
+        config = AgentConfig(
+            client=client,
+            model="auto",
+        )
+        agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
+        assert agent.model == "auto"
+
+
+class TestManifestAgentBehavior:
+    """Tests for agent behavior with Manifest provider."""
+
+    @pytest.fixture
+    def mock_manifest_instructor(self):
+        mock = Mock(spec=instructor.Instructor)
+        mock.chat = Mock()
+        mock.chat.completions = Mock()
+        mock.chat.completions.create = Mock(return_value=BasicChatOutputSchema(chat_message="Manifest response"))
+        mock_response = BasicChatOutputSchema(chat_message="Manifest response")
+        mock_iter = Mock()
+        mock_iter.__iter__ = Mock(return_value=iter([mock_response]))
+        mock.chat.completions.create_partial.return_value = mock_iter
+        return mock
+
+    @pytest.fixture
+    def manifest_agent(self, mock_manifest_instructor):
+        config = AgentConfig(
+            client=mock_manifest_instructor,
+            model="auto",
+        )
+        return AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
+
+    def test_run_with_manifest(self, manifest_agent, mock_manifest_instructor):
+        """Test that agent.run works with Manifest mock client."""
+        user_input = BasicChatInputSchema(chat_message="Hello from Manifest test")
+        response = manifest_agent.run(user_input)
+        assert response.chat_message == "Manifest response"
+        mock_manifest_instructor.chat.completions.create.assert_called_once()
+
+    def test_run_passes_correct_model(self, manifest_agent, mock_manifest_instructor):
+        """Test that the correct model name is passed to the API."""
+        user_input = BasicChatInputSchema(chat_message="Test")
+        manifest_agent.run(user_input)
+        call_kwargs = mock_manifest_instructor.chat.completions.create.call_args
+        assert call_kwargs.kwargs["model"] == "auto"
+
+    def test_run_stream_with_manifest(self, manifest_agent):
+        """Test that streaming works with Manifest mock client."""
+        user_input = BasicChatInputSchema(chat_message="Stream test")
+        responses = list(manifest_agent.run_stream(user_input))
+        assert len(responses) == 1
+        assert responses[0].chat_message == "Manifest response"
+
+    def test_history_tracking_with_manifest(self, manifest_agent):
+        """Test that chat history is properly tracked."""
+        user_input = BasicChatInputSchema(chat_message="First message")
+        manifest_agent.run(user_input)
+        history = manifest_agent.history.get_history()
+        assert len(history) == 2  # user + assistant
+
+    def test_system_prompt_with_manifest(self, mock_manifest_instructor):
+        """Test that system prompt works correctly with Manifest."""
+        spg = SystemPromptGenerator(
+            background=["You are a helpful Manifest-powered assistant."],
+        )
+        config = AgentConfig(
+            client=mock_manifest_instructor,
+            model="auto",
+            system_prompt_generator=spg,
+        )
+        agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
+        prompt = agent.system_prompt_generator.generate_prompt()
+        assert "Manifest" in prompt
+
+    def test_model_api_parameters_with_manifest(self, mock_manifest_instructor):
+        """Test that custom API parameters are passed through."""
+        config = AgentConfig(
+            client=mock_manifest_instructor,
+            model="auto",
+            model_api_parameters={"temperature": 0.7, "max_tokens": 1024},
+        )
+        agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
+        assert agent.model_api_parameters["temperature"] == 0.7
+        assert agent.model_api_parameters["max_tokens"] == 1024
+
+    def test_manifest_reset_history(self, manifest_agent):
+        """Test that history reset works with Manifest agent."""
+        user_input = BasicChatInputSchema(chat_message="Test")
+        manifest_agent.run(user_input)
+        manifest_agent.reset_history()
+        history = manifest_agent.history.get_history()
+        assert len(history) == 0
+
+
+class TestManifestProviderSetup:
+    """Tests for the provider setup function from the quickstart example."""
+
+    def test_setup_client_manifest_by_number(self):
+        """Test setup_client with provider number '8'."""
+        from openai import OpenAI
+
+        api_key = "test-manifest-key"
+        raw_client = OpenAI(base_url="https://app.manifest.build/v1", api_key=api_key)
+        client = instructor.from_openai(raw_client)
+        assert isinstance(client, instructor.Instructor)
+
+    def test_manifest_env_var_detection(self):
+        """Test that MANIFEST_API_KEY env var can be used."""
+        with patch.dict(os.environ, {"MANIFEST_API_KEY": "test-env-key"}):
+            api_key = os.getenv("MANIFEST_API_KEY")
+            assert api_key == "test-env-key"
+
+    def test_manifest_base_url_env_var(self):
+        """Test that MANIFEST_BASE_URL env var can override the default."""
+        with patch.dict(os.environ, {"MANIFEST_BASE_URL": "http://localhost:3001/v1"}):
+            base_url = os.getenv("MANIFEST_BASE_URL", "https://app.manifest.build/v1")
+            assert base_url == "http://localhost:3001/v1"
+
+    def test_manifest_base_url_default(self):
+        """Test that the default base URL is used when env var is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            base_url = os.getenv("MANIFEST_BASE_URL", "https://app.manifest.build/v1")
+            assert base_url == "https://app.manifest.build/v1"

--- a/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
+++ b/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
@@ -82,6 +82,15 @@ def setup_client(provider):
         model = "MiniMax-M2.7"
         model_api_parameters = {"max_tokens": 2048}
         assistant_role = "assistant"
+    elif provider == "8" or provider == "manifest":
+        from openai import OpenAI as ManifestClient
+
+        api_key = os.getenv("MANIFEST_API_KEY")
+        base_url = os.getenv("MANIFEST_BASE_URL", "https://app.manifest.build/v1")
+        client = instructor.from_openai(ManifestClient(base_url=base_url, api_key=api_key))
+        model = "auto"
+        model_api_parameters = {"max_tokens": 2048}
+        assistant_role = "assistant"
     else:
         raise ValueError(f"Unsupported provider: {provider}")
 
@@ -89,7 +98,7 @@ def setup_client(provider):
 
 
 # Prompt the user to choose a provider from one in the list below.
-providers_list = ["openai", "anthropic", "groq", "ollama", "gemini", "openrouter", "minimax"]
+providers_list = ["openai", "anthropic", "groq", "ollama", "gemini", "openrouter", "minimax", "manifest"]
 y = "bold yellow"
 b = "bold blue"
 g = "bold green"

--- a/claude-plugin/atomic-agents/CHANGELOG.md
+++ b/claude-plugin/atomic-agents/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Atomic Agents Claude Code Plugin will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-04-20
+
+### Added
+
+- **Manifest provider support.** Added [Manifest](https://manifest.build/) (smart LLM router) as an officially documented provider. Manifest scores each request and routes it to the cheapest capable model. Integration uses the OpenAI-compatible pattern (`instructor.from_openai` with custom `base_url`). Updated provider matrix, quickstart example, docs, and added unit tests.
+
 ## [2.0.1] - 2026-04-16
 
 Bug-fix release addressing two recurring false positives from `atomic-reviewer` reported in [issue #238](https://github.com/BrainBlend-AI/atomic-agents/issues/238).

--- a/claude-plugin/atomic-agents/agents/atomic-reviewer.md
+++ b/claude-plugin/atomic-agents/agents/atomic-reviewer.md
@@ -45,7 +45,7 @@ Work through the categories below in order. Raise an issue only at ≥75% confid
 - `model` is appropriate for the task (not a reasoning model for trivial work, not a weak model for hard reasoning).
 - `history` is present when multi-turn state is needed; absent when each call is independent.
 - `assistant_role="model"` for Gemini, `"assistant"` elsewhere.
-- `AgentConfig.mode` matches the Instructor factory mode (`Mode.TOOLS` for OpenAI/Anthropic, `Mode.JSON` for Groq/Ollama/MiniMax, `Mode.GENAI_TOOLS` for Gemini).
+- `AgentConfig.mode` matches the Instructor factory mode (`Mode.TOOLS` for OpenAI/Anthropic/OpenRouter/Manifest, `Mode.JSON` for Groq/Ollama/MiniMax, `Mode.GENAI_TOOLS` for Gemini).
 - Provider-specific required params: `max_tokens` in `model_api_parameters` for Anthropic; `reasoning_effort` for reasoning models when intended.
 
 ### 3. Tools (`BaseTool`)

--- a/claude-plugin/atomic-agents/skills/framework/references/providers.md
+++ b/claude-plugin/atomic-agents/skills/framework/references/providers.md
@@ -28,6 +28,7 @@ Model IDs in this file are illustrative. Provider model names change often — c
 | Gemini | `instructor.from_genai(google.genai.Client(...), mode=Mode.GENAI_TOOLS)` | `Mode.GENAI_TOOLS` | `"model"` | Native |
 | OpenRouter | `instructor.from_openai(OpenAI(base_url=..., api_key=...))` | `Mode.TOOLS` | `"assistant"` | OpenAI-compatible |
 | MiniMax | `instructor.from_openai(OpenAI(base_url=..., api_key=...), mode=Mode.JSON)` | `Mode.JSON` | `"assistant"` | OpenAI-compatible |
+| Manifest | `instructor.from_openai(OpenAI(base_url=..., api_key=...))` | `Mode.TOOLS` | `"assistant"` | OpenAI-compatible |
 
 The `mode` value is passed to `AgentConfig(mode=...)` **and** sometimes to the Instructor factory itself. Match them.
 
@@ -139,12 +140,30 @@ model = "MiniMax-M2.7"
 api_params = {"max_tokens": 2048}
 ```
 
+## Manifest (smart LLM router)
+
+```python
+import os, instructor
+from openai import OpenAI
+
+client = instructor.from_openai(OpenAI(
+    base_url=os.environ.get("MANIFEST_BASE_URL", "https://app.manifest.build/v1"),
+    api_key=os.environ["MANIFEST_API_KEY"],
+))
+model = "auto"
+api_params = {"max_tokens": 2048}
+# In AgentConfig: mode=Mode.TOOLS
+```
+
+Manifest is a smart router that scores each request across 23 dimensions and routes it to the cheapest model capable of handling it. The `"auto"` model lets Manifest pick automatically. Cloud: `https://app.manifest.build/v1`. Self-hosted: `http://localhost:3001/v1`.
+
 ## Picking a model
 
 - **Drafting / simple chat** — `gpt-5-mini`, `claude-haiku-4-5`, or a Groq Llama for cost.
 - **Tool use, multi-agent routing** — `gpt-5` or `claude-sonnet-4-6`.
 - **Hardest reasoning** — `claude-opus-4-6` or reasoning-tier OpenAI models.
 - **Local / offline** — Ollama with `llama3.1` or a code-specialized variant.
+- **Cost optimization** — Manifest with `"auto"` to route each request to the cheapest capable model.
 
 The framework is indifferent to provider choice — schemas and hooks behave the same. Swap `model` and the provider wiring, leave the rest alone.
 

--- a/claude-plugin/atomic-agents/skills/new-app/SKILL.md
+++ b/claude-plugin/atomic-agents/skills/new-app/SKILL.md
@@ -16,7 +16,7 @@ This skill is opinionated. Produce a complete, tested skeleton the user can run 
 Ask these questions in one message, not one-at-a-time. Skip any the user already answered (including via `$ARGUMENTS`).
 
 1. **Project name** — used as both directory name and package name. Default from `$ARGUMENTS` if provided. Normalize to `kebab-case` for the directory and `snake_case` for the package.
-2. **LLM provider** — OpenAI / Anthropic / Groq / Ollama / Gemini / OpenRouter / MiniMax. Default: OpenAI.
+2. **LLM provider** — OpenAI / Anthropic / Groq / Ollama / Gemini / OpenRouter / MiniMax / Manifest. Default: OpenAI.
 3. **Agent type** — a rough one-liner. Shapes the default `SystemPromptGenerator` content and the starter schema pair. Defaults to a generic chat agent.
 4. **Tooling** — `uv` (default, because the repo uses uv) or `pip + venv`.
 
@@ -88,6 +88,7 @@ Per-provider AgentConfig knobs — match the Instructor factory mode on `AgentCo
 - **Groq / Ollama / MiniMax**: `mode=Mode.JSON` (Instructor factory also uses `Mode.JSON`).
 - **Gemini**: `assistant_role="model"` and `mode=Mode.GENAI_TOOLS` (Instructor factory uses `Mode.GENAI_TOOLS`).
 - **OpenRouter**: `mode=Mode.TOOLS`.
+- **Manifest**: `mode=Mode.TOOLS`.
 
 ### `README.md`
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -373,13 +373,22 @@ def setup_client(provider):
         )
         model = "mistral/ministral-8b"
 
+    elif provider == "manifest":
+        from openai import OpenAI as ManifestClient
+        api_key = os.getenv("MANIFEST_API_KEY")
+        base_url = os.getenv("MANIFEST_BASE_URL", "https://app.manifest.build/v1")
+        client = instructor.from_openai(
+            ManifestClient(base_url=base_url, api_key=api_key)
+        )
+        model = "auto"
+
     else:
         raise ValueError(f"Unsupported provider: {provider}")
 
     return client, model
 
 # Prompt for provider choice
-provider = console.input("Choose a provider (openai/anthropic/groq/ollama/gemini/openrouter): ").lower()
+provider = console.input("Choose a provider (openai/anthropic/groq/ollama/gemini/openrouter/manifest): ").lower()
 
 # Set up client and model
 client, model = setup_client(provider)
@@ -402,6 +411,7 @@ The framework supports multiple providers through Instructor:
 - **Groq**: Fast inference for open models
 - **Ollama**: Local models (requires Ollama running)
 - **Gemini**: Google's Gemini models
+- **Manifest**: Smart LLM router for cost optimization
 
 Each provider requires its own API key (except Ollama) which should be set in environment variables:
 
@@ -420,6 +430,9 @@ export GEMINI_API_KEY="your-gemini-key"
 
 # OpenRouter
 export OPENROUTER_API_KEY="your-openrouter-key"
+
+# Manifest
+export MANIFEST_API_KEY="your-manifest-key"
 ```
 
 ## Running the Examples


### PR DESCRIPTION
## Summary

- Add [Manifest](https://manifest.build/) as an officially documented LLM provider
- Manifest is a smart LLM router that scores each request across 23 dimensions and routes it to the cheapest capable model
- Uses the existing OpenAI-compatible pattern (`instructor.from_openai` with custom `base_url`), same as OpenRouter and MiniMax

## Changes

- **Quickstart example** (`4_basic_chatbot_different_providers.py`): added Manifest as provider option #8
- **Provider reference** (`providers.md`): added matrix entry, setup code section, and cost optimization mention
- **Quickstart guide** (`quickstart.md`): added Manifest to code example, provider list, and env vars
- **README**: added Manifest to provider compatibility list
- **New-app skill** (`SKILL.md`): added Manifest to provider list and mode docs
- **Reviewer config** (`atomic-reviewer.md`): added Manifest to `Mode.TOOLS` providers
- **Changelog**: added v2.0.2 entry
- **Unit tests**: 16 new tests following the MiniMax provider test pattern (all passing)

## Configuration

```python
from openai import OpenAI
import instructor

client = instructor.from_openai(
    OpenAI(
        base_url=os.getenv("MANIFEST_BASE_URL", "https://app.manifest.build/v1"),
        api_key=os.getenv("MANIFEST_API_KEY"),
    )
)
model = "auto"  # Manifest picks the optimal model
```

## Test plan

- [x] Verified Manifest API returns valid OpenAI-compatible responses via curl
- [x] Verified AtomicAgent initializes correctly with Manifest config
- [x] All 16 new unit tests pass
- [x] All 15 existing MiniMax provider tests still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)