### PR TITLE
fix(release): clean dist/ before build so only the new version is published

### DIFF
--- a/build_and_deploy.ps1
+++ b/build_and_deploy.ps1
@@ -190,6 +190,7 @@ if ($dryRun) {
     Write-Host "[DRY RUN] Would perform the following actions:"
     Write-Host "[DRY RUN] - Build consolidated atomic-agents package"
     Write-Host "[DRY RUN] - Install dependencies with uv sync"
+    Write-Host "[DRY RUN] - Clean stale artifacts from dist directory"
     Write-Host "[DRY RUN] - Build package with uv build"
     Write-Host "[DRY RUN] - Configure PyPI token"
     Write-Host "[DRY RUN] - Upload to PyPI with uv publish"
@@ -202,6 +203,12 @@ Write-Host "Building consolidated atomic-agents package..."
 
 # Install dependencies
 uv sync
+
+# Remove stale artifacts so we only publish the version we just built
+if (Test-Path "dist") {
+    Write-Host "Cleaning dist directory of stale artifacts..."
+    Remove-Item "dist\*" -Recurse -Force
+}
 
 # Build the package
 uv build


### PR DESCRIPTION
## Problem

During the v2.8.0 release, `uv publish` re-attempted uploading every old wheel/sdist sitting in `dist/` (2.6.0 through 2.7.5). PyPI ignores already-present files, so it was harmless this time — but it's noisy, slows the publish, and risks confusing failures if an old artifact ever differs.

Root cause: `uv build` only *adds* to `dist/`, and `uv publish` (no args) uploads **everything** in `dist/`. Stale artifacts accumulate across releases.

## Fix

Clear `dist/` right before `uv build`, so only the freshly built artifacts for the current version exist when `uv publish` runs. The dry-run summary lists the new step too.

## Verification

- `build_and_deploy.ps1 patch --dry` parses and now lists `- Clean stale artifacts from dist directory`.
- Dry run makes no changes (confirmed `git status` clean apart from the script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)