### PR TITLE
feat(minimax): default MiniMax model to M3

### DIFF
--- a/atomic-agents/tests/agents/test_minimax_integration.py
+++ b/atomic-agents/tests/agents/test_minimax_integration.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _make_minimax_agent(model="MiniMax-M2.7", **agent_kwargs):
+def _make_minimax_agent(model="MiniMax-M3", **agent_kwargs):
     """Helper to create a MiniMax-backed agent."""
     from openai import OpenAI
 
@@ -71,7 +71,7 @@ class TestMiniMaxLiveChat:
             api_key=os.environ["MINIMAX_API_KEY"],
         )
         client = instructor.from_openai(raw, mode=instructor.Mode.JSON)
-        config = AgentConfig(client=client, model="MiniMax-M2.7", mode=instructor.Mode.JSON)
+        config = AgentConfig(client=client, model="MiniMax-M3", mode=instructor.Mode.JSON)
         agent = AtomicAgent[BasicChatInputSchema, AnalysisOutput](config)
 
         response = agent.run(BasicChatInputSchema(chat_message="I love this product, it's amazing!"))

--- a/atomic-agents/tests/agents/test_minimax_provider.py
+++ b/atomic-agents/tests/agents/test_minimax_provider.py
@@ -40,9 +40,9 @@ class TestMiniMaxClientSetup:
         client = _create_minimax_client()
         config = AgentConfig(
             client=client,
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
         )
-        assert config.model == "MiniMax-M2.7"
+        assert config.model == "MiniMax-M3"
         assert config.assistant_role == "assistant"
 
     def test_minimax_agent_initialization(self):
@@ -50,31 +50,21 @@ class TestMiniMaxClientSetup:
         client = _create_minimax_client()
         config = AgentConfig(
             client=client,
+            model="MiniMax-M3",
+        )
+        agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
+        assert agent.model == "MiniMax-M3"
+        assert agent.assistant_role == "assistant"
+
+    def test_minimax_m27_legacy_model(self):
+        """Test that the legacy M2.7 model variant still works."""
+        client = _create_minimax_client()
+        config = AgentConfig(
+            client=client,
             model="MiniMax-M2.7",
         )
         agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
         assert agent.model == "MiniMax-M2.7"
-        assert agent.assistant_role == "assistant"
-
-    def test_minimax_m25_model(self):
-        """Test that M2.5 model variant works."""
-        client = _create_minimax_client()
-        config = AgentConfig(
-            client=client,
-            model="MiniMax-M2.5",
-        )
-        agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
-        assert agent.model == "MiniMax-M2.5"
-
-    def test_minimax_m25_highspeed_model(self):
-        """Test that M2.5-highspeed model variant works."""
-        client = _create_minimax_client()
-        config = AgentConfig(
-            client=client,
-            model="MiniMax-M2.5-highspeed",
-        )
-        agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
-        assert agent.model == "MiniMax-M2.5-highspeed"
 
 
 class TestMiniMaxAgentBehavior:
@@ -96,7 +86,7 @@ class TestMiniMaxAgentBehavior:
     def minimax_agent(self, mock_minimax_instructor):
         config = AgentConfig(
             client=mock_minimax_instructor,
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
         )
         return AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
 
@@ -112,7 +102,7 @@ class TestMiniMaxAgentBehavior:
         user_input = BasicChatInputSchema(chat_message="Test")
         minimax_agent.run(user_input)
         call_kwargs = mock_minimax_instructor.chat.completions.create.call_args
-        assert call_kwargs.kwargs["model"] == "MiniMax-M2.7"
+        assert call_kwargs.kwargs["model"] == "MiniMax-M3"
 
     def test_run_stream_with_minimax(self, minimax_agent):
         """Test that streaming works with MiniMax mock client."""
@@ -135,7 +125,7 @@ class TestMiniMaxAgentBehavior:
         )
         config = AgentConfig(
             client=mock_minimax_instructor,
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             system_prompt_generator=spg,
         )
         agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)
@@ -146,7 +136,7 @@ class TestMiniMaxAgentBehavior:
         """Test that custom API parameters are passed through."""
         config = AgentConfig(
             client=mock_minimax_instructor,
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             model_api_parameters={"temperature": 0.7, "max_tokens": 1024},
         )
         agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](config)

--- a/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
+++ b/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
@@ -79,7 +79,7 @@ def setup_client(provider):
             MiniMaxClient(base_url="https://api.minimax.io/v1", api_key=api_key),
             mode=instructor.Mode.JSON,
         )
-        model = "MiniMax-M2.7"
+        model = "MiniMax-M3"
         model_api_parameters = {"max_tokens": 2048}
         assistant_role = "assistant"
     else:

--- a/claude-plugin/atomic-agents/skills/framework/references/providers.md
+++ b/claude-plugin/atomic-agents/skills/framework/references/providers.md
@@ -135,7 +135,7 @@ client = instructor.from_openai(
     OpenAI(base_url="https://api.minimax.io/v1", api_key=os.environ["MINIMAX_API_KEY"]),
     mode=Mode.JSON,
 )
-model = "MiniMax-M2.7"
+model = "MiniMax-M3"   # current default; "MiniMax-M2.7" remains available as a legacy option
 api_params = {"max_tokens": 2048}
 ```
 


### PR DESCRIPTION
## Summary

MiniMax released M3 as the new flagship model. This PR updates the default MiniMax model id from `MiniMax-M2.7` to `MiniMax-M3` so new users land on the recommended model out of the box.

### What changed

- `atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py` — provider example now uses `MiniMax-M3`
- `claude-plugin/atomic-agents/skills/framework/references/providers.md` — reference snippet uses `M3`; comment notes `M2.7` is still available as a legacy option
- `atomic-agents/tests/agents/test_minimax_provider.py` — default in unit tests bumped to `M3`; `test_minimax_m25_model` and `test_minimax_m25_highspeed_model` (both deprecated variants) replaced by a single `test_minimax_m27_legacy_model` that pins continued support for `M2.7`
- `atomic-agents/tests/agents/test_minimax_integration.py` — integration helper default and the structured-output test pin to `MiniMax-M3`

### What did **not** change

- `https://api.minimax.io/v1` base URL
- `MINIMAX_API_KEY` env var name
- `Mode.JSON` Instructor mode and `assistant_role="assistant"`
- The OpenAI-compatible client wiring

## Test plan

- [x] `pytest atomic-agents/tests/agents/test_minimax_provider.py -v` — 14 passed
- [x] `pytest atomic-agents/tests` — 321 passed (no regressions in the rest of the suite)
- [x] `black --check --line-length=127` — clean
- [x] `flake8 --max-line-length=127` — 0 errors
- [x] Live smoke against `https://api.minimax.io/v1` with `model="MiniMax-M3"` reaches the API (request accepted; only blocked by account balance on this side)