### PR TITLE
Rebrand BrainBlend -> Eigenwise; repoint URLs to eigenwise GitHub home

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "brainblend-plugins",
+  "name": "eigenwise",
   "description": "Official plugins for the Atomic Agents framework - a lightweight, modular system for building AI agents with Pydantic and Instructor",
   "owner": {
-    "name": "BrainBlend AI",
-    "email": "support@brainblend.ai"
+    "name": "Kenny Vaneetvelde",
+    "email": "kenny@eigenwise.io"
   },
   "plugins": [
     {
@@ -12,13 +12,13 @@
       "description": "Skills plus explorer and reviewer subagents for building, scaffolding, understanding, and auditing applications with the Atomic Agents Python framework. Progressive-disclosure references for schemas, agents, tools, context providers, prompts, orchestration, memory, hooks, providers, project structure, and testing — plus isolated-context subagents for codebase mapping and code review, and a new-app scaffolder.",
       "version": "2.0.1",
       "author": {
-        "name": "BrainBlend AI",
-        "email": "support@brainblend.ai"
+        "name": "Kenny Vaneetvelde",
+        "email": "kenny@eigenwise.io"
       },
       "source": "./claude-plugin/atomic-agents",
       "category": "development",
-      "homepage": "https://github.com/BrainBlend-AI/atomic-agents",
-      "repository": "https://github.com/BrainBlend-AI/atomic-agents",
+      "homepage": "https://github.com/eigenwise/atomic-agents",
+      "repository": "https://github.com/eigenwise/atomic-agents",
       "license": "MIT",
       "keywords": [
         "atomic-agents",

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 <img src="./.assets/logo.png" alt="Atomic Agents" width="350"/>
 
 [![PyPI version](https://badge.fury.io/py/atomic-agents.svg)](https://badge.fury.io/py/atomic-agents)
-[![Documentation](https://img.shields.io/badge/docs-read%20the%20docs-blue?logo=readthedocs&style=flat-square)](https://brainblend-ai.github.io/atomic-agents/)
-[![Build Docs](https://github.com/BrainBlend-AI/atomic-agents/actions/workflows/docs.yml/badge.svg)](https://github.com/BrainBlend-AI/atomic-agents/actions/workflows/docs.yml)
-[![Code Quality](https://github.com/BrainBlend-AI/atomic-agents/actions/workflows/code-quality.yml/badge.svg)](https://github.com/BrainBlend-AI/atomic-agents/actions/workflows/code-quality.yml)
+[![Documentation](https://img.shields.io/badge/docs-read%20the%20docs-blue?logo=readthedocs&style=flat-square)](https://eigenwise.github.io/atomic-agents/)
+[![Build Docs](https://github.com/eigenwise/atomic-agents/actions/workflows/docs.yml/badge.svg)](https://github.com/eigenwise/atomic-agents/actions/workflows/docs.yml)
+[![Code Quality](https://github.com/eigenwise/atomic-agents/actions/workflows/code-quality.yml/badge.svg)](https://github.com/eigenwise/atomic-agents/actions/workflows/code-quality.yml)
 [![Discord](https://img.shields.io/badge/chat-on%20discord-7289DA?logo=discord&style=flat-square)](https://discord.gg/J3W9b5AZJR)
 [![PyPI downloads](https://img.shields.io/pypi/dm/atomic-agents?style=flat-square)](https://pypi.org/project/atomic-agents/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/atomic-agents?style=flat-square)](https://pypi.org/project/atomic-agents/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat-square)](LICENSE)
-[![GitHub Stars](https://img.shields.io/github/stars/BrainBlend-AI/atomic-agents?style=social)](https://github.com/BrainBlend-AI/atomic-agents/stargazers)
-[![GitHub Forks](https://img.shields.io/github/forks/BrainBlend-AI/atomic-agents?style=social)](https://github.com/BrainBlend-AI/atomic-agents/network/members)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/BrainBlend-AI/atomic-agents)
+[![GitHub Stars](https://img.shields.io/github/stars/eigenwise/atomic-agents?style=social)](https://github.com/eigenwise/atomic-agents/stargazers)
+[![GitHub Forks](https://img.shields.io/github/forks/eigenwise/atomic-agents?style=social)](https://github.com/eigenwise/atomic-agents/network/members)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/eigenwise/atomic-agents)
 
 ## What is Atomic Agents?
 
@@ -262,9 +262,9 @@ This design pattern simplifies the process of chaining agents and tools, making 
 
 ## Examples & Documentation
 
-[![Read the Docs](https://img.shields.io/badge/docs-read%20the%20docs-blue?logo=readthedocs&style=for-the-badge)](https://brainblend-ai.github.io/atomic-agents/)
+[![Read the Docs](https://img.shields.io/badge/docs-read%20the%20docs-blue?logo=readthedocs&style=for-the-badge)](https://eigenwise.github.io/atomic-agents/)
 
-[Visit the Documentation Site »](https://brainblend-ai.github.io/atomic-agents/)
+[Visit the Documentation Site »](https://eigenwise.github.io/atomic-agents/)
 
 ### Quickstart Examples
 
@@ -374,7 +374,7 @@ Atomic Agents uses a monorepo structure with the following main components:
 For local development, you can install from the repository:
 
 ```bash
-git clone https://github.com/BrainBlend-AI/atomic-agents.git
+git clone https://github.com/eigenwise/atomic-agents.git
 cd atomic-agents
 uv sync
 ```
@@ -419,5 +419,5 @@ If you want to learn more about the motivation and philosophy behind Atomic Agen
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=BrainBlend-AI/atomic-agents&type=Date)](https://star-history.com/#BrainBlend-AI/atomic-agents&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=eigenwise/atomic-agents&type=Date)](https://star-history.com/#eigenwise/atomic-agents&Date)
 

--- a/atomic-assembler/atomic_assembler/app.py
+++ b/atomic-assembler/atomic_assembler/app.py
@@ -50,7 +50,7 @@ class AtomicAssembler(App):
 
     def open_github(self) -> None:
         """Open the Atomic Agents GitHub page in a web browser."""
-        webbrowser.open("https://github.com/BrainBlend-AI/atomic-agents")
+        webbrowser.open("https://github.com/eigenwise/atomic-agents")
 
     def push_file_explorer(self, **kwargs):
         """Push the file explorer screen in file mode."""

--- a/atomic-assembler/atomic_assembler/constants.py
+++ b/atomic-assembler/atomic_assembler/constants.py
@@ -14,7 +14,7 @@ TITLE_FONT: str = "big"
 TOOLS_SUBFOLDER: str = "atomic-forge/tools"
 
 # Base URL for GitHub repository
-GITHUB_BASE_URL: str = "https://github.com/BrainBlend-AI/atomic-agents.git"
+GITHUB_BASE_URL: str = "https://github.com/eigenwise/atomic-agents.git"
 GITHUB_BRANCH: str = "main"
 
 

--- a/claude-plugin/atomic-agents/.claude-plugin/plugin.json
+++ b/claude-plugin/atomic-agents/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "2.1.0",
   "description": "Skills plus explorer and reviewer subagents for building, scaffolding, understanding, and auditing applications with the Atomic Agents Python framework. Includes the umbrella `framework` skill, action-oriented `create-atomic-schema` / `create-atomic-agent` / `create-atomic-tool` / `create-atomic-context-provider` skills, the `new-app` scaffolder, progressive-disclosure reference material for prompts, orchestration, memory, hooks, providers, project structure, and testing, and isolated-context subagents for codebase mapping and code review.",
   "author": {
-    "name": "BrainBlend AI",
-    "email": "support@brainblendai.com"
+    "name": "Kenny Vaneetvelde",
+    "email": "kenny@eigenwise.io"
   },
-  "homepage": "https://github.com/BrainBlend-AI/atomic-agents",
-  "repository": "https://github.com/BrainBlend-AI/atomic-agents",
+  "homepage": "https://github.com/eigenwise/atomic-agents",
+  "repository": "https://github.com/eigenwise/atomic-agents",
   "license": "MIT"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A versatile framework for creating and managing intelligent agent
 readme = "README.md"
 license = "MIT"
 authors = [
-    { name = "Kenny Vaneetvelde", email = "kenny.vaneetvelde@gmail.com" }
+    { name = "Kenny Vaneetvelde", email = "kenny@eigenwise.io" }
 ]
 requires-python = ">=3.12"
 classifiers = [
@@ -37,8 +37,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/BrainBlend-AI/atomic-agents"
-Repository = "https://github.com/BrainBlend-AI/atomic-agents"
+Homepage = "https://github.com/eigenwise/atomic-agents"
+Repository = "https://github.com/eigenwise/atomic-agents"
 
 [project.scripts]
 atomic = "atomic_assembler.main:main"


### PR DESCRIPTION
Repo moved from BrainBlend-AI to the eigenwise GitHub account. This repoints all references:

- README badges, docs site (eigenwise.github.io), clone URL, star-history
- pyproject project.urls + author email (Kenny Vaneetvelde <kenny@eigenwise.io>)
- Claude plugin manifests: marketplace slug -> `eigenwise`, owner/author -> Kenny Vaneetvelde
- atomic-assembler CLI clone + browser-open URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)