### PR TITLE
Finish BrainBlend -> Eigenwise rebrand; modernize plugin install docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "atomic-agents",
       "description": "Skills plus explorer and reviewer subagents for building, scaffolding, understanding, and auditing applications with the Atomic Agents Python framework. Progressive-disclosure references for schemas, agents, tools, context providers, prompts, orchestration, memory, hooks, providers, project structure, and testing — plus isolated-context subagents for codebase mapping and code review, and a new-app scaffolder.",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "author": {
         "name": "Kenny Vaneetvelde",
         "email": "kenny@eigenwise.io"

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -91,7 +91,7 @@ Brief description of the feature.
 - Fix 1
 
 ### Full Changelog
-https://github.com/BrainBlend-AI/atomic-agents/compare/vOLD...vNEW
+https://github.com/eigenwise/atomic-agents/compare/vOLD...vNEW
 ```
 
 ## Checklist

--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,1 +1,1 @@
-github: KennyVaneetvelde
+github: Eigenwise

--- a/UPGRADE_DOC.md
+++ b/UPGRADE_DOC.md
@@ -749,7 +749,7 @@ If you encounter runtime errors:
 
 If you encounter issues during migration:
 
-1. Check the [GitHub Issues](https://github.com/BrainBlend-AI/atomic-agents/issues)
+1. Check the [GitHub Issues](https://github.com/eigenwise/atomic-agents/issues)
 2. Join the [Discord community](https://discord.gg/J3W9b5AZJR)
 3. Visit the [subreddit](https://www.reddit.com/r/AtomicAgents/)
 

--- a/agents.md
+++ b/agents.md
@@ -225,7 +225,7 @@ Through Instructor, Atomic Agents supports all major LLM providers:
 
 ```bash
 # Clone the repository
-git clone https://github.com/BrainBlend-AI/atomic-agents.git
+git clone https://github.com/eigenwise/atomic-agents.git
 cd atomic-monorepo
 
 # Install dependencies
@@ -305,8 +305,8 @@ Recent improvements include:
 ## Community & Resources
 
 ### Documentation
-- **Main Docs:** https://brainblend-ai.github.io/atomic-agents/
-- **Repository:** https://github.com/BrainBlend-AI/atomic-agents
+- **Main Docs:** https://eigenwise.github.io/atomic-agents/
+- **Repository:** https://github.com/eigenwise/atomic-agents
 - **PyPI:** https://pypi.org/project/atomic-agents/
 
 ### Community

--- a/atomic-agents/tests/agents/test_atomic_agent.py
+++ b/atomic-agents/tests/agents/test_atomic_agent.py
@@ -421,7 +421,7 @@ def test_messages_sync_after_run(mock_instructor, mock_system_prompt_generator):
     Test that agent.messages includes the assistant response after run() completes.
 
     Regression test for GitHub issue #194:
-    https://github.com/BrainBlend-AI/atomic-agents/issues/194
+    https://github.com/eigenwise/atomic-agents/issues/194
 
     The issue was that agent.messages only contained the system prompt and user message
     after run(), while agent.history.get_history() correctly included the assistant response.

--- a/atomic-agents/tests/context/test_chat_history.py
+++ b/atomic-agents/tests/context/test_chat_history.py
@@ -102,7 +102,7 @@ def test_get_history(history):
     Ensure non-ASCII characters are serialized without Unicode escaping, because
     it can cause issue with some OpenAI models like GPT-4.1.
 
-    Reference ticket: https://github.com/BrainBlend-AI/atomic-agents/issues/138.
+    Reference ticket: https://github.com/eigenwise/atomic-agents/issues/138.
     """
     history.add_message("user", InputSchema(test_field="Hello"))
     history.add_message("assistant", MockOutputSchema(test_field="Hi there"))

--- a/atomic-examples/basic-multimodal/README.md
+++ b/atomic-examples/basic-multimodal/README.md
@@ -18,7 +18,7 @@ This example demonstrates how to use the Atomic Agents framework to analyze imag
 1. Clone the main Atomic Agents repository:
 
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 2. Navigate to the basic-multimodal directory:

--- a/atomic-examples/basic-pdf-analysis/README.md
+++ b/atomic-examples/basic-pdf-analysis/README.md
@@ -13,7 +13,7 @@ This example demonstrates how to use the Atomic Agents framework to analyze a PD
 
 1. Clone the main Atomic Agents repository:
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 2. Navigate to the basic-pdf-analysis directory:

--- a/atomic-examples/deep-research/README.md
+++ b/atomic-examples/deep-research/README.md
@@ -19,7 +19,7 @@ Every agent has a single responsibility and reads / contributes to a shared `Res
 
 1. **Clone the main Atomic Agents repository:**
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 2. **Navigate to the Deep Research directory:**

--- a/atomic-examples/deep-research/deep_research/tools/webpage_scraper.py
+++ b/atomic-examples/deep-research/deep_research/tools/webpage_scraper.py
@@ -270,7 +270,7 @@ if __name__ == "__main__":
     try:
         result = scraper.run(
             WebpageScraperToolInputSchema(
-                url="https://github.com/BrainBlend-AI/atomic-agents",
+                url="https://github.com/eigenwise/atomic-agents",
                 include_links=True,
             )
         )

--- a/atomic-examples/deep-research/pyproject.toml
+++ b/atomic-examples/deep-research/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 description = "Deep research example for Atomic Agents"
 readme = "README.md"
 authors = [
-    { name = "Kenny Vaneetvelde", email = "kenny@brainblendai.com" }
+    { name = "Kenny Vaneetvelde", email = "kenny@eigenwise.io" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/atomic-examples/dspy-integration/README.md
+++ b/atomic-examples/dspy-integration/README.md
@@ -767,7 +767,7 @@ MIT License - Part of the Atomic Agents monorepo.
 ## Further Reading
 
 - [DSPy Documentation](https://dspy-docs.vercel.app/)
-- [Atomic Agents Documentation](https://github.com/BrainBlend-AI/atomic-agents)
+- [Atomic Agents Documentation](https://github.com/eigenwise/atomic-agents)
 - [Instructor Documentation](https://python.useinstructor.com/)
 - [Pydantic Documentation](https://docs.pydantic.dev/)
 

--- a/atomic-examples/dspy-integration/pyproject.toml
+++ b/atomic-examples/dspy-integration/pyproject.toml
@@ -11,7 +11,7 @@ version = "1.0.0"
 description = "DSPy + Atomic Agents integration example - combining prompt optimization with type-safe structured outputs"
 readme = "README.md"
 authors = [
-    { name = "BrainBlend AI", email = "kenny@brainblendai.com" }
+    { name = "Kenny Vaneetvelde", email = "kenny@eigenwise.io" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/atomic-examples/fastapi-memory/pyproject.toml
+++ b/atomic-examples/fastapi-memory/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 description = "Simple FastAPI integration example with Atomic Agents"
 readme = "README.md"
 authors = [
-    { name = "BrainBlend AI" }
+    { name = "Kenny Vaneetvelde", email = "kenny@eigenwise.io" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/atomic-examples/hooks-example/README.md
+++ b/atomic-examples/hooks-example/README.md
@@ -15,7 +15,7 @@ This example demonstrates the powerful hook system integration in AtomicAgent, w
 
 1. Clone the main Atomic Agents repository:
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 2. Navigate to the hooks-example directory:

--- a/atomic-examples/mcp-agent/README.md
+++ b/atomic-examples/mcp-agent/README.md
@@ -67,7 +67,7 @@ This example shows the flexibility of the MCP architecture with two distinct tra
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    cd atomic-agents/atomic-examples/mcp-agent
    ```
 
@@ -205,5 +205,5 @@ Try queries like:
 
 ## Learn More
 
-- [Atomic Agents Documentation](https://github.com/BrainBlend-AI/atomic-agents)
+- [Atomic Agents Documentation](https://github.com/eigenwise/atomic-agents)
 - [Model Context Protocol](https://modelcontextprotocol.io/)

--- a/atomic-examples/nested-multimodal/README.md
+++ b/atomic-examples/nested-multimodal/README.md
@@ -3,8 +3,8 @@
 This example demonstrates how to use the Atomic Agents framework with **nested multimodal content** — images and PDFs inside nested Pydantic schemas, not just at the top level.
 
 This showcases the fixes for:
-- [#208](https://github.com/BrainBlend-AI/atomic-agents/issues/208): ChatHistory crashes with `TypeError` when schemas have both multimodal fields and nested Pydantic models
-- [#141](https://github.com/BrainBlend-AI/atomic-agents/issues/141): AgentMemory doesn't support multimodal data inside nested schemas
+- [#208](https://github.com/eigenwise/atomic-agents/issues/208): ChatHistory crashes with `TypeError` when schemas have both multimodal fields and nested Pydantic models
+- [#141](https://github.com/eigenwise/atomic-agents/issues/141): AgentMemory doesn't support multimodal data inside nested schemas
 
 ## Features
 

--- a/atomic-examples/orchestration-agent/README.md
+++ b/atomic-examples/orchestration-agent/README.md
@@ -13,7 +13,7 @@ This example demonstrates how to create an Orchestrator Agent that intelligently
 
 1. Clone the Atomic Agents repository:
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 2. Navigate to the orchestration-agent directory:

--- a/atomic-examples/orchestration-agent/pyproject.toml
+++ b/atomic-examples/orchestration-agent/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 description = "Orchestration agent example for Atomic Agents"
 readme = "README.md"
 authors = [
-    { name = "KennyVaneetvelde", email = "kenny@inosta.be" }
+    { name = "Kenny Vaneetvelde", email = "kenny@eigenwise.io" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/atomic-examples/progressive-disclosure/README.md
+++ b/atomic-examples/progressive-disclosure/README.md
@@ -163,7 +163,7 @@ User Query: "Calculate (5 + 3) * 2 and reverse 'hello'"
 
 ```bash
 # Clone the repository
-git clone https://github.com/BrainBlend-AI/atomic-agents
+git clone https://github.com/eigenwise/atomic-agents
 cd atomic-agents/atomic-examples/progressive-disclosure
 
 # Install dependencies
@@ -275,7 +275,7 @@ if __name__ == "__main__":
 - [Anthropic: Code Execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp)
 - [FastMCP Documentation](https://gofastmcp.com)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
-- [Atomic Agents Documentation](https://github.com/BrainBlend-AI/atomic-agents)
+- [Atomic Agents Documentation](https://github.com/eigenwise/atomic-agents)
 
 ## See Also
 

--- a/atomic-examples/progressive-disclosure/pyproject.toml
+++ b/atomic-examples/progressive-disclosure/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 description = "Progressive Disclosure example for Atomic Agents - demonstrating Anthropic's pattern for efficient MCP tool loading"
 readme = "README.md"
 authors = [
-    { name = "KennyVaneetvelde", email = "kenny@inosta.be" }
+    { name = "Kenny Vaneetvelde", email = "kenny@eigenwise.io" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/atomic-examples/progressive-disclosure/servers/data_server/pyproject.toml
+++ b/atomic-examples/progressive-disclosure/servers/data_server/pyproject.toml
@@ -10,7 +10,7 @@ name = "pd-data-server"
 version = "0.1.0"
 description = "MCP server with data/list tools for progressive disclosure demo"
 authors = [
-    { name = "KennyVaneetvelde", email = "kenny@inosta.be" }
+    { name = "Kenny Vaneetvelde", email = "kenny@eigenwise.io" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/atomic-examples/progressive-disclosure/servers/math_server/pyproject.toml
+++ b/atomic-examples/progressive-disclosure/servers/math_server/pyproject.toml
@@ -10,7 +10,7 @@ name = "pd-math-server"
 version = "0.1.0"
 description = "MCP server with arithmetic tools for progressive disclosure demo"
 authors = [
-    { name = "KennyVaneetvelde", email = "kenny@inosta.be" }
+    { name = "Kenny Vaneetvelde", email = "kenny@eigenwise.io" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/atomic-examples/progressive-disclosure/servers/text_server/pyproject.toml
+++ b/atomic-examples/progressive-disclosure/servers/text_server/pyproject.toml
@@ -10,7 +10,7 @@ name = "pd-text-server"
 version = "0.1.0"
 description = "MCP server with text manipulation tools for progressive disclosure demo"
 authors = [
-    { name = "KennyVaneetvelde", email = "kenny@inosta.be" }
+    { name = "Kenny Vaneetvelde", email = "kenny@eigenwise.io" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/atomic-examples/quickstart/README.md
+++ b/atomic-examples/quickstart/README.md
@@ -9,7 +9,7 @@ To run these examples:
 1. Clone the main Atomic Agents repository:
 
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 2. Navigate to the quickstart directory:

--- a/atomic-examples/rag-chatbot/README.md
+++ b/atomic-examples/rag-chatbot/README.md
@@ -17,7 +17,7 @@ To get started with the RAG Chatbot:
 1. **Clone the main Atomic Agents repository:**
 
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 2. **Navigate to the RAG Chatbot directory:**

--- a/atomic-examples/web-search-agent/README.md
+++ b/atomic-examples/web-search-agent/README.md
@@ -36,7 +36,7 @@ Make sure to add these lines to `settings.tml`:
 1. Clone the Atomic Agents repository:
 
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 1. Navigate to the web-search-agent directory:

--- a/atomic-examples/youtube-summarizer/README.md
+++ b/atomic-examples/youtube-summarizer/README.md
@@ -8,7 +8,7 @@ To get started with the YouTube Summarizer:
 
 1. **Clone the main Atomic Agents repository:**
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 2. **Navigate to the YouTube Summarizer directory:**

--- a/atomic-examples/youtube-to-recipe/README.md
+++ b/atomic-examples/youtube-to-recipe/README.md
@@ -9,7 +9,7 @@ To get started with the YouTube Recipe Extractor:
 1. **Clone the main Atomic Agents repository:**
 
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents
+   git clone https://github.com/eigenwise/atomic-agents
    ```
 
 2. **Navigate to the YouTube Recipe Extractor directory:**

--- a/atomic-forge/tools/arxiv_search/tool/arxiv_search.py
+++ b/atomic-forge/tools/arxiv_search/tool/arxiv_search.py
@@ -83,7 +83,7 @@ class ArxivSearchToolConfig(BaseToolConfig):
 
     base_url: str = Field(default="https://export.arxiv.org/api/query", description="Base URL of the arXiv API.")
     user_agent: str = Field(
-        default="atomic-agents-arxiv-tool/1.0 (+https://github.com/BrainBlend-AI/atomic-agents)",
+        default="atomic-agents-arxiv-tool/1.0 (+https://github.com/eigenwise/atomic-agents)",
         description="User agent string for arXiv requests.",
     )
     timeout: float = Field(default=20.0, ge=1.0, le=120.0, description="HTTP request timeout in seconds.")

--- a/atomic-forge/tools/hackernews_search/tool/hackernews_search.py
+++ b/atomic-forge/tools/hackernews_search/tool/hackernews_search.py
@@ -84,7 +84,7 @@ class HackerNewsSearchToolConfig(BaseToolConfig):
 
     base_url: str = Field(default="https://hn.algolia.com/api/v1", description="Algolia HN search base URL.")
     user_agent: str = Field(
-        default="atomic-agents-hackernews-tool/1.0 (+https://github.com/BrainBlend-AI/atomic-agents)",
+        default="atomic-agents-hackernews-tool/1.0 (+https://github.com/eigenwise/atomic-agents)",
         description="User agent for HTTP requests.",
     )
     timeout: float = Field(default=15.0, ge=1.0, le=120.0, description="HTTP request timeout in seconds.")

--- a/atomic-forge/tools/weather/tool/weather.py
+++ b/atomic-forge/tools/weather/tool/weather.py
@@ -155,7 +155,7 @@ class WeatherToolConfig(BaseToolConfig):
         description="Open-Meteo forecast endpoint.",
     )
     user_agent: str = Field(
-        default="atomic-agents-weather-tool/1.0 (+https://github.com/BrainBlend-AI/atomic-agents)",
+        default="atomic-agents-weather-tool/1.0 (+https://github.com/eigenwise/atomic-agents)",
         description="User agent for HTTP requests.",
     )
     timeout: float = Field(default=15.0, ge=1.0, le=120.0, description="HTTP request timeout in seconds.")

--- a/atomic-forge/tools/webpage_scraper/tool/webpage_scraper.py
+++ b/atomic-forge/tools/webpage_scraper/tool/webpage_scraper.py
@@ -275,7 +275,7 @@ if __name__ == "__main__":  # pragma: no cover
 
     result = scraper.run(
         WebpageScraperToolInputSchema(
-            url="https://github.com/BrainBlend-AI/atomic-agents",
+            url="https://github.com/eigenwise/atomic-agents",
             include_links=True,
         )
     )

--- a/atomic-forge/tools/wikipedia_search/tool/wikipedia_search.py
+++ b/atomic-forge/tools/wikipedia_search/tool/wikipedia_search.py
@@ -75,7 +75,7 @@ class WikipediaSearchToolConfig(BaseToolConfig):
     """Configuration for the WikipediaSearchTool."""
 
     user_agent: str = Field(
-        default="atomic-agents-wikipedia-tool/1.0 (+https://github.com/BrainBlend-AI/atomic-agents)",
+        default="atomic-agents-wikipedia-tool/1.0 (+https://github.com/eigenwise/atomic-agents)",
         description="User agent for Wikipedia API requests. Wikipedia asks for a descriptive UA.",
     )
     timeout: float = Field(default=15.0, ge=1.0, le=120.0, description="HTTP request timeout in seconds.")

--- a/claude-plugin/atomic-agents/CHANGELOG.md
+++ b/claude-plugin/atomic-agents/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.1] - 2026-04-16
 
-Bug-fix release addressing two recurring false positives from `atomic-reviewer` reported in [issue #238](https://github.com/BrainBlend-AI/atomic-agents/issues/238).
+Bug-fix release addressing two recurring false positives from `atomic-reviewer` reported in [issue #238](https://github.com/eigenwise/atomic-agents/issues/238).
 
 ### Fixed
 

--- a/claude-plugin/atomic-agents/LICENSE
+++ b/claude-plugin/atomic-agents/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 BrainBlend AI
+Copyright (c) 2025 Kenny Vaneetvelde
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/claude-plugin/atomic-agents/README.md
+++ b/claude-plugin/atomic-agents/README.md
@@ -1,6 +1,6 @@
 # Atomic Agents Plugin for Claude Code
 
-A Claude Code plugin that gives Claude deep, just-in-time knowledge of the [Atomic Agents](https://github.com/BrainBlend-AI/atomic-agents) Python framework. When you work on an Atomic Agents codebase, Claude picks up the right patterns for schemas, agents, tools, context providers, prompts, orchestration, and provider wiring — without you having to paste documentation or repeat conventions.
+A Claude Code plugin that gives Claude deep, just-in-time knowledge of the [Atomic Agents](https://github.com/eigenwise/atomic-agents) Python framework. When you work on an Atomic Agents codebase, Claude picks up the right patterns for schemas, agents, tools, context providers, prompts, orchestration, and provider wiring — without you having to paste documentation or repeat conventions.
 
 ## What you get
 
@@ -15,22 +15,25 @@ This follows the hybrid pattern Anthropic themselves ship: reference skills for 
 
 ## Install
 
-### Recommended — from the BrainBlend marketplace
+### Recommended — from the Eigenwise marketplace
 
 ```
-/plugin marketplace add BrainBlend-AI/atomic-agents
-/plugin install atomic-agents@brainblend-plugins
+/plugin marketplace add eigenwise/atomic-agents
+/plugin install atomic-agents@eigenwise
 ```
 
 This path gets you the latest version immediately. We control the marketplace, so pushes to `main` in this repo reach users on the next `/plugin marketplace update` (and auto-update is on by default for git-hosted marketplaces you've explicitly added).
 
-### From the official Anthropic marketplace
+### From Anthropic's community marketplace
+
+Once the plugin is approved in Anthropic's public community directory, add that marketplace and install from it:
 
 ```
-/plugin install atomic-agents@claude-plugins-official
+/plugin marketplace add anthropics/claude-plugins-community
+/plugin install atomic-agents@claude-community
 ```
 
-> **Note (April 2026)**: The entry in the official marketplace currently uses a source type that silently drops the plugin's subdirectory `path`, causing the plugin to load empty (zero agents, zero skills). Tracking fix at [anthropics/claude-plugins-official#1436](https://github.com/anthropics/claude-plugins-official/issues/1436). Until that's applied, use the BrainBlend marketplace above.
+The community directory is submission-only — entries are submitted through the [plugin directory submission form](https://clau.de/plugin-directory-submission) (pull requests against the catalog repo are closed automatically). After approval, CI re-pins the entry to new commits on this repo's `main` as they land, so the Eigenwise marketplace above always tracks the same source.
 
 ### Team projects (declarative)
 
@@ -39,12 +42,12 @@ To require this plugin for everyone who opens a given repo, add it to the projec
 ```json
 {
   "extraKnownMarketplaces": {
-    "brainblend-plugins": {
-      "source": { "source": "github", "repo": "BrainBlend-AI/atomic-agents" }
+    "eigenwise": {
+      "source": { "source": "github", "repo": "eigenwise/atomic-agents" }
     }
   },
   "enabledPlugins": {
-    "atomic-agents@brainblend-plugins": true
+    "atomic-agents@eigenwise": true
   }
 }
 ```
@@ -103,8 +106,8 @@ MIT — see `LICENSE`.
 
 ## Links
 
-- Framework: https://github.com/BrainBlend-AI/atomic-agents
-- Examples: https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples
+- Framework: https://github.com/eigenwise/atomic-agents
+- Examples: https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples
 - Changelog: `CHANGELOG.md`
 
-Built by [BrainBlend AI](https://github.com/BrainBlend-AI).
+Built by [Eigenwise](https://github.com/eigenwise).

--- a/claude-plugin/atomic-agents/agents/atomic-reviewer.md
+++ b/claude-plugin/atomic-agents/agents/atomic-reviewer.md
@@ -6,7 +6,7 @@ model: sonnet
 color: red
 ---
 
-You are an expert reviewer of code written against the [Atomic Agents](https://github.com/BrainBlend-AI/atomic-agents) Python framework. Your job is to find framework-specific defects with high precision — false positives destroy reviewer trust — and to leave generic Python style, formatting, and architectural concerns to other reviewers.
+You are an expert reviewer of code written against the [Atomic Agents](https://github.com/eigenwise/atomic-agents) Python framework. Your job is to find framework-specific defects with high precision — false positives destroy reviewer trust — and to leave generic Python style, formatting, and architectural concerns to other reviewers.
 
 ## Scope
 

--- a/claude-plugin/atomic-agents/skills/framework/references/memory.md
+++ b/claude-plugin/atomic-agents/skills/framework/references/memory.md
@@ -128,7 +128,7 @@ Only safe when the agents run **sequentially** on the same thread. Concurrent ru
 
 Each agent has its own `ChatHistory()`. Outputs are passed via typed schemas at the call site. Default for multi-agent orchestration — keeps state contained.
 
-### Agent-to-agent messaging (addresses [GitHub issue #58](https://github.com/BrainBlend-AI/atomic-agents/issues/58))
+### Agent-to-agent messaging (addresses [GitHub issue #58](https://github.com/eigenwise/atomic-agents/issues/58))
 
 Each agent keeps its own history; the orchestrator manually injects the other agent's output as a `"user"` message and calls `run(None)` to let the recipient continue.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Atomic Agents! This guide will he
 
 There are many ways to contribute to Atomic Agents:
 
-1. **Report Bugs**: Submit bug reports on our [Issue Tracker](https://github.com/BrainBlend-AI/atomic-agents/issues)
+1. **Report Bugs**: Submit bug reports on our [Issue Tracker](https://github.com/eigenwise/atomic-agents/issues)
 2. **Suggest Features**: Share your ideas for new features or improvements
 3. **Improve Documentation**: Help us make the documentation clearer and more comprehensive
 4. **Submit Code**: Fix bugs, add features, or create new tools
@@ -155,8 +155,8 @@ If you need help:
 
 - Join our [Reddit community](https://www.reddit.com/r/AtomicAgents/)
 - Check the [documentation](https://atomic-agents.readthedocs.io/)
-- Ask questions on [GitHub Discussions](https://github.com/BrainBlend-AI/atomic-agents/discussions)
+- Ask questions on [GitHub Discussions](https://github.com/eigenwise/atomic-agents/discussions)
 
 ## Code of Conduct
 
-Please note that this project is released with a Code of Conduct. By participating in this project you agree to abide by its terms. You can find the full text in our [GitHub repository](https://github.com/BrainBlend-AI/atomic-agents/blob/main/CODE_OF_CONDUCT.md).
+Please note that this project is released with a Code of Conduct. By participating in this project you agree to abide by its terms. You can find the full text in our [GitHub repository](https://github.com/eigenwise/atomic-agents/blob/main/CODE_OF_CONDUCT.md).

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -18,7 +18,7 @@ Simple examples to get started with the framework:
 - Custom input/output schemas
 - Multiple provider support
 
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/quickstart)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/quickstart)** - Browse the complete source code and run the examples
 
 ## Hooks System
 
@@ -31,7 +31,7 @@ Comprehensive monitoring and error handling with the AtomicAgent hook system:
 - Production-ready error isolation
 - Real-time performance dashboards
 
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/hooks-example)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/hooks-example)** - Browse the complete source code and run the examples
 
 ## Basic Multimodal
 
@@ -42,7 +42,7 @@ Examples of working with images and text:
 - Visual content generation
 - Multi-image comparisons
 
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/basic-multimodal)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/basic-multimodal)** - Browse the complete source code and run the examples
 
 ## RAG Chatbot
 
@@ -54,7 +54,7 @@ Build context-aware chatbots with retrieval-augmented generation:
 - Source attribution
 - Follow-up suggestions
 
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/rag-chatbot)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/rag-chatbot)** - Browse the complete source code and run the examples
 
 ## Web Search Agent
 
@@ -66,7 +66,7 @@ Create agents that can search and analyze web content:
 - Multi-source research
 - Citation tracking
 
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/web-search-agent)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/web-search-agent)** - Browse the complete source code and run the examples
 
 ## Deep Research
 
@@ -78,7 +78,7 @@ Perform comprehensive research tasks:
 - Structured output generation
 - Citation management
 
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/deep-research)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/deep-research)** - Browse the complete source code and run the examples
 
 ## YouTube Summarizer
 
@@ -90,7 +90,7 @@ Extract and analyze information from videos:
 - Timestamp linking
 - Chapter generation
 
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/youtube-summarizer)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/youtube-summarizer)** - Browse the complete source code and run the examples
 
 ## YouTube to Recipe
 
@@ -102,7 +102,7 @@ Convert cooking videos into structured recipes:
 - Step-by-step instructions
 - Time and temperature conversion
 
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/youtube-to-recipe)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/youtube-to-recipe)** - Browse the complete source code and run the examples
 
 ## Orchestration Agent
 
@@ -114,7 +114,7 @@ Coordinate multiple agents for complex tasks:
 - Error handling
 - Result aggregation
 
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/orchestration-agent)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/orchestration-agent)** - Browse the complete source code and run the examples
 
 ## MCP Agent
 
@@ -127,4 +127,4 @@ Build intelligent agents using the Model Context Protocol:
 - Extensible tool architecture
 
 [View MCP Agent Documentation](mcp_agent.md)
-📂 **[View on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/mcp-agent)** - Browse the complete source code and run the examples
+📂 **[View on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/mcp-agent)** - Browse the complete source code and run the examples

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -112,7 +112,7 @@ Atomic Agents is designed to be provider-agnostic. Here's how to work with diffe
 
 If you need help, you can:
 
-1. Check our [GitHub Issues](https://github.com/BrainBlend-AI/atomic-agents/issues)
+1. Check our [GitHub Issues](https://github.com/eigenwise/atomic-agents/issues)
 2. Join our [Reddit community](https://www.reddit.com/r/AtomicAgents/)
 3. Read through our examples in the repository
 4. Review the example projects in `atomic-examples/`

--- a/docs/guides/memory.md
+++ b/docs/guides/memory.md
@@ -25,7 +25,7 @@ This guide covers everything you need to know about managing conversation memory
 
 ### The Problem This Solves
 
-A common question from developers (see [GitHub Issue #58](https://github.com/BrainBlend-AI/atomic-agents/issues/58)):
+A common question from developers (see [GitHub Issue #58](https://github.com/eigenwise/atomic-agents/issues/58)):
 
 > "In most of the examples only the initial message is added, not any subsequent runs. Is this automatic?"
 
@@ -1212,4 +1212,4 @@ Key takeaways:
 4. **Context Providers**: Inject dynamic information (RAG, user data, time) into system prompts
 5. **Multi-Agent**: Use shared history, agent-to-agent messaging, or context providers depending on your needs
 
-For questions or issues, visit our [GitHub repository](https://github.com/BrainBlend-AI/atomic-agents) or [Reddit community](https://www.reddit.com/r/AtomicAgents/).
+For questions or issues, visit our [GitHub repository](https://github.com/eigenwise/atomic-agents) or [Reddit community](https://www.reddit.com/r/AtomicAgents/).

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -2,8 +2,8 @@
 
 **See also:**
 
-- [Quickstart runnable examples on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/quickstart)
-- [All Atomic Agents examples on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples)
+- [Quickstart runnable examples on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/quickstart)
+- [All Atomic Agents examples on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples)
 
 This guide will help you get started with the Atomic Agents framework. We'll cover basic usage, custom agents, and different AI providers.
 
@@ -448,4 +448,4 @@ After trying these examples, you can:
 
 ## Explore More Examples
 
-For more advanced usage and examples, please check out the [Atomic Agents examples on GitHub](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples). These examples demonstrate various capabilities of the framework including custom schemas, advanced history usage, tool integration, and more.
+For more advanced usage and examples, please check out the [Atomic Agents examples on GitHub](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples). These examples demonstrate various capabilities of the framework including custom schemas, advanced history usage, tool integration, and more.

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -118,7 +118,7 @@ Use this pattern when:
 - The set of candidate tools is small (a handful, not dozens — Union grows the prompt).
 - You want the LLM's reasoning for the choice to be inspectable (extend the output schema with a `reasoning: str` field).
 
-A complete, runnable version of this pattern lives in [`atomic-examples/orchestration-agent`](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/orchestration-agent). The [Orchestration guide](orchestration.md) covers tool-selection, multi-agent pipelines, dynamic routing, and parallel execution in more depth.
+A complete, runnable version of this pattern lives in [`atomic-examples/orchestration-agent`](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/orchestration-agent). The [Orchestration guide](orchestration.md) covers tool-selection, multi-agent pipelines, dynamic routing, and parallel execution in more depth.
 
 ## Picking a pattern
 
@@ -286,7 +286,7 @@ class MyTool(BaseTool[MyToolInputSchema, MyToolOutputSchema]):
 
 ## Next steps
 
-1. Browse available tools in the [Atomic Forge directory](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-forge).
-2. Try Pattern 1 by chaining a query agent into a search tool — the [README's "Chaining Schemas" example](https://github.com/BrainBlend-AI/atomic-agents#chaining-schemas-and-agents) is a good starting point.
-3. Try Pattern 2 by running the [orchestration-agent example](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/orchestration-agent).
+1. Browse available tools in the [Atomic Forge directory](https://github.com/eigenwise/atomic-agents/tree/main/atomic-forge).
+2. Try Pattern 1 by chaining a query agent into a search tool — the [README's "Chaining Schemas" example](https://github.com/eigenwise/atomic-agents#chaining-schemas-and-agents) is a good starting point.
+3. Try Pattern 2 by running the [orchestration-agent example](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/orchestration-agent).
 4. Build your own tool and contribute it back via the Atomic Forge.

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,22 +116,22 @@ print(response)
 
 ## Example Projects
 
-Check out our example projects in our [GitHub repository](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples):
+Check out our example projects in our [GitHub repository](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples):
 
-- [Quickstart Examples](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/quickstart): Simple examples to get started
-- [Hooks System](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/hooks-example): Comprehensive monitoring, error handling, and performance metrics
-- [Basic Multimodal](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/basic-multimodal): Analyze images with text
-- [RAG Chatbot](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/rag-chatbot): Build context-aware chatbots
-- [Web Search Agent](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/web-search-agent): Create agents that perform web searches
-- [Deep Research](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/deep-research): Perform deep research tasks
-- [YouTube Summarizer](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/youtube-summarizer): Extract knowledge from videos
-- [YouTube to Recipe](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/youtube-to-recipe): Convert cooking videos into structured recipes
-- [Orchestration Agent](https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/orchestration-agent): Coordinate multiple agents for complex tasks
+- [Quickstart Examples](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/quickstart): Simple examples to get started
+- [Hooks System](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/hooks-example): Comprehensive monitoring, error handling, and performance metrics
+- [Basic Multimodal](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/basic-multimodal): Analyze images with text
+- [RAG Chatbot](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/rag-chatbot): Build context-aware chatbots
+- [Web Search Agent](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/web-search-agent): Create agents that perform web searches
+- [Deep Research](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/deep-research): Perform deep research tasks
+- [YouTube Summarizer](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/youtube-summarizer): Extract knowledge from videos
+- [YouTube to Recipe](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/youtube-to-recipe): Convert cooking videos into structured recipes
+- [Orchestration Agent](https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/orchestration-agent): Coordinate multiple agents for complex tasks
 
 ## Community & Support
 
-- [GitHub Repository](https://github.com/BrainBlend-AI/atomic-agents)
-- [Issue Tracker](https://github.com/BrainBlend-AI/atomic-agents/issues)
+- [GitHub Repository](https://github.com/eigenwise/atomic-agents)
+- [Issue Tracker](https://github.com/eigenwise/atomic-agents/issues)
 - [Reddit Community](https://www.reddit.com/r/AtomicAgents/)
 
 ## Indices and References

--- a/guides/DEV_GUIDE.md
+++ b/guides/DEV_GUIDE.md
@@ -36,7 +36,7 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 1. Fork the repository on GitHub.
 2. Clone your fork locally:
    ```bash
-   git clone https://github.com/BrainBlend-AI/atomic-agents.git
+   git clone https://github.com/eigenwise/atomic-agents.git
    cd atomic-agents
    ```
 3. Install dependencies using uv:

--- a/scripts/generate_llms_files.py
+++ b/scripts/generate_llms_files.py
@@ -115,7 +115,7 @@ def generate_documentation_only() -> str:
     content = create_section_divider("ATOMIC AGENTS DOCUMENTATION", 1)
     content += "This file contains the complete documentation for the Atomic Agents framework.\n"
     content += "Generated for use with Large Language Models and AI assistants.\n"
-    content += f"Project Repository: https://github.com/BrainBlend-AI/atomic-agents\n"
+    content += f"Project Repository: https://github.com/eigenwise/atomic-agents\n"
     
     content += create_section_divider("DOCUMENTATION", 1)
     content += extract_documentation_from_html()
@@ -128,7 +128,7 @@ def generate_source_code_only() -> str:
     content = create_section_divider("ATOMIC AGENTS SOURCE CODE", 1)
     content += "This file contains the complete source code for the Atomic Agents framework.\n"
     content += "Generated for use with Large Language Models and AI assistants.\n"
-    content += f"Project Repository: https://github.com/BrainBlend-AI/atomic-agents\n"
+    content += f"Project Repository: https://github.com/eigenwise/atomic-agents\n"
     
     files = get_files_to_include(ATOMIC_AGENTS_DIR, SOURCE_CODE_EXTENSIONS)
     
@@ -143,7 +143,7 @@ def generate_examples_only() -> str:
     content = create_section_divider("ATOMIC AGENTS EXAMPLES", 1)
     content += "This file contains all example implementations using the Atomic Agents framework.\n"
     content += "Each example includes its README documentation and complete source code.\n"
-    content += f"Project Repository: https://github.com/BrainBlend-AI/atomic-agents\n"
+    content += f"Project Repository: https://github.com/eigenwise/atomic-agents\n"
     
     # Get all example directories
     example_dirs = [d for d in ATOMIC_EXAMPLES_DIR.iterdir() if d.is_dir() and d.name not in EXCLUDE_DIRS]
@@ -153,7 +153,7 @@ def generate_examples_only() -> str:
         content += create_section_divider(f"Example: {example_dir.name}", 2)
         
         # Add GitHub link
-        github_url = f"https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/{example_dir.name}"
+        github_url = f"https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/{example_dir.name}"
         content += f"**View on GitHub:** {github_url}\n\n"
         
         # Process README first if it exists
@@ -184,7 +184,7 @@ def generate_full_content() -> str:
     content = create_section_divider("ATOMIC AGENTS - COMPREHENSIVE DOCUMENTATION, SOURCE CODE, AND EXAMPLES", 1)
     content += "This file contains the complete documentation, source code, and examples for the Atomic Agents framework.\n"
     content += "Generated for use with Large Language Models and AI assistants.\n"
-    content += f"Project Repository: https://github.com/BrainBlend-AI/atomic-agents\n"
+    content += f"Project Repository: https://github.com/eigenwise/atomic-agents\n"
     content += f"\nTable of Contents:\n"
     content += "1. Documentation\n"
     content += "2. Atomic Agents Source Code\n"
@@ -214,7 +214,7 @@ def generate_full_content() -> str:
     for example_dir in example_dirs:
         content += create_section_divider(f"Example: {example_dir.name}", 2)
         
-        github_url = f"https://github.com/BrainBlend-AI/atomic-agents/tree/main/atomic-examples/{example_dir.name}"
+        github_url = f"https://github.com/eigenwise/atomic-agents/tree/main/atomic-examples/{example_dir.name}"
         content += f"**View on GitHub:** {github_url}\n\n"
         
         readme_files = list(example_dir.glob("README.*"))
@@ -236,7 +236,7 @@ def generate_full_content() -> str:
     
     content += create_section_divider("END OF DOCUMENT", 1)
     content += "This comprehensive documentation was generated for use with AI assistants and LLMs.\n"
-    content += "For the latest version, please visit: https://github.com/BrainBlend-AI/atomic-agents\n"
+    content += "For the latest version, please visit: https://github.com/eigenwise/atomic-agents\n"
     
     return content
 


### PR DESCRIPTION
## What

Completes the BrainBlend -> Eigenwise rebrand. The previous rebrand commit left ~40 files still referencing the old `BrainBlend-AI` org and the old maintainer identity. This sweeps the rest and brings the plugin's install docs in line with Anthropic's **current** community-marketplace process.

## Changes

**De-branding (repo-wide)**
- `github.com/BrainBlend-AI/atomic-agents` -> `eigenwise/atomic-agents` across docs, every example README, the four+ Forge tool User-Agent strings, tests, and the `llms.txt` generator.
- Docs link `brainblend-ai.github.io` -> `eigenwise.github.io` (no custom domain/CNAME exists).
- Funding handle `KennyVaneetvelde` -> `Eigenwise`.
- Example `pyproject.toml` authors + plugin `LICENSE` -> `Kenny Vaneetvelde <kenny@eigenwise.io>` (matches `marketplace.json` owner and the root `LICENSE` holder).

**Plugin packaging**
- Self-hosted marketplace renamed `brainblend-plugins` -> `eigenwise` (README install commands + team `settings.json` snippet).
- `marketplace.json` plugin version `2.0.1` -> `2.1.0` to match `plugin.json` (they had drifted).
- Replaced the stale "official Anthropic marketplace" section (and the dead April-2026 `#1436` path-bug note) with the current flow: `anthropics/claude-plugins-community` installed as `@claude-community`, submitted via the [submission form](https://clau.de/plugin-directory-submission), auto-repinned from `main` by CI.

## External marketplace (needs your action — cannot be done in this repo)

The atomic-agents entry currently in `anthropics/claude-plugins-official` still points at `BrainBlend-AI` with a pinned SHA. It keeps working via GitHub's org-transfer redirect, but to fully de-brand it the plugin must be (re)submitted through the **form** at https://clau.de/plugin-directory-submission (or `platform.claude.com/plugins/submit`). PRs to the Anthropic catalog repos are auto-closed; there is no PR path anymore.

## Verification
- `black --check` clean (195 files unchanged)
- `flake8` clean (exit 0)
- `pytest atomic-agents` -> 321 passed, 3 skipped
- `git grep -i brainblend` and old-identity grep both return no matches

## Note
11 other example `pyproject.toml` files use `kenny.vaneetvelde@gmail.com` (set in the prior rebrand, not brainblend-related), left untouched. There's now a gmail/eigenwise.io split — happy to unify either way if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)