### PR TITLE
Plugin 2.2.0: troubleshoot skill, new-app emits AGENTS.md + CLAUDE.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,8 +9,8 @@
   "plugins": [
     {
       "name": "atomic-agents",
-      "description": "Skills plus explorer and reviewer subagents for building, scaffolding, understanding, and auditing applications with the Atomic Agents Python framework. Progressive-disclosure references for schemas, agents, tools, context providers, prompts, orchestration, memory, hooks, providers, project structure, and testing — plus isolated-context subagents for codebase mapping and code review, and a new-app scaffolder.",
-      "version": "2.1.0",
+      "description": "Skills plus explorer and reviewer subagents for building, scaffolding, debugging, understanding, and auditing applications with the Atomic Agents Python framework. Progressive-disclosure references for schemas, agents, tools, context providers, prompts, orchestration, memory, hooks, providers, project structure, and testing — plus a troubleshoot diagnostic, isolated-context subagents for codebase mapping and code review, and a new-app scaffolder.",
+      "version": "2.2.0",
       "author": {
         "name": "Kenny Vaneetvelde",
         "email": "kenny@eigenwise.io"

--- a/.claude/.codebase-info/.map-state.json
+++ b/.claude/.codebase-info/.map-state.json
@@ -2,7 +2,7 @@
   "tool": "codebase-mapper",
   "version": "2.8.0",
   "mappedAt": "2026-07-18",
-  "gitCommit": "ffcdca567bd460af080734598762112a9af6857e",
+  "gitCommit": "73dbc8be54f4ca32e71d28f5d9a7648dd9628c9b",
   "documents": [
     "architecture.md",
     "tech-landscape.md",
@@ -19,7 +19,7 @@
     "INDEX.md": "17eaa0ba82f159465e126597aac349c6e4429330887b58742636734e15854313",
     "architecture.md": "7c908f047e6b0f08824ccd7c3f674ad47bd547dde234d0bd424a6d2784c0cbb6",
     "tech-landscape.md": "cad1a11e5e63013a10cf07657d248196d0e3e4e14203eba7b777c1c123628198",
-    "directory-structure.md": "7d04bf29e9005508af316e29ded0c2f082a8dca561a279faecbc682f3bf5db6f",
+    "directory-structure.md": "7e3fc4c3c8b89b6627beabcb6ddebd74b0ac7094e52718926fc87a94c932df84",
     "entry-points.md": "6bd4ccae3d975196e03fc2c4e86007eba89f1f6427232fd8adce78ec97d6b432",
     "modules.md": "1238c76664edb1c1667fda23f39507bcab5b760b57a3a3728d7104b2cf8032e7",
     "communication.md": "49741a7455b0f162881e1cfb2d797dc8e3832cc8782796bbcb8a10529f2c5a0b",

--- a/.claude/.codebase-info/directory-structure.md
+++ b/.claude/.codebase-info/directory-structure.md
@@ -20,6 +20,9 @@ atomic-agents/                  # repo root (uv workspace)
 │   ├── tools/<tool>/           #   one folder per tool: tool/<tool>.py, tests/, pyproject.toml
 │   └── guides/                 #   tool authoring guides (e.g. tool_structure.md)
 ├── atomic-examples/            # 16 runnable example apps (each its own project)
+├── claude-plugin/atomic-agents/ # AI-assistant plugin: 7 skills + 2 subagents (Claude Code plugin,
+│                               #   also installable cross-tool via `npx skills add eigenwise/atomic-agents`)
+├── .claude-plugin/             # marketplace.json — plugin marketplace manifest (drives npx skills discovery)
 ├── docs/                       # Sphinx + MyST documentation (api/, guides/, examples/)
 ├── guides/                     # DEV_GUIDE.md and contributor guides
 ├── scripts/                    # generate_llms_files.py (llms.txt index + llms-*.txt bundles)

--- a/claude-plugin/atomic-agents/.claude-plugin/plugin.json
+++ b/claude-plugin/atomic-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "atomic-agents",
-  "version": "2.1.0",
-  "description": "Skills plus explorer and reviewer subagents for building, scaffolding, understanding, and auditing applications with the Atomic Agents Python framework. Includes the umbrella `framework` skill, action-oriented `create-atomic-schema` / `create-atomic-agent` / `create-atomic-tool` / `create-atomic-context-provider` skills, the `new-app` scaffolder, progressive-disclosure reference material for prompts, orchestration, memory, hooks, providers, project structure, and testing, and isolated-context subagents for codebase mapping and code review.",
+  "version": "2.2.0",
+  "description": "Skills plus explorer and reviewer subagents for building, scaffolding, debugging, understanding, and auditing applications with the Atomic Agents Python framework. Includes the umbrella `framework` skill, action-oriented `create-atomic-schema` / `create-atomic-agent` / `create-atomic-tool` / `create-atomic-context-provider` skills, the `troubleshoot` diagnostic skill, the `new-app` scaffolder (emits AGENTS.md + CLAUDE.md), progressive-disclosure reference material for prompts, orchestration, memory, hooks, providers, project structure, and testing, and isolated-context subagents for codebase mapping and code review.",
   "author": {
     "name": "Kenny Vaneetvelde",
     "email": "kenny@eigenwise.io"

--- a/claude-plugin/atomic-agents/CHANGELOG.md
+++ b/claude-plugin/atomic-agents/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to the Atomic Agents Claude Code Plugin will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2026-07-18
+
+### Added
+
+- **`troubleshoot` skill** — diagnostic workflow for the "my agent is broken" moment. Symptom table keyed on the framework's real error messages (docstring enforcement, `AgentConfig.client` validation, provider role/mode errors, `HTTP_STREAM`, history misuse), each with a mechanical fix and a re-run verification step. Escalation map into the `framework` reference files; `framework` routes concrete errors here.
+- **`new-app` emits `AGENTS.md` + `CLAUDE.md`** into every scaffolded project — framework conventions any coding assistant reads, with `CLAUDE.md` as a one-line `@AGENTS.md` import (the documented, Windows-safe pattern). Template includes per-provider quirk lines.
+- Cross-tool install path documented: `npx skills add eigenwise/atomic-agents` works for Cursor, Copilot, Codex, Windsurf, Gemini CLI, and other skills-compatible assistants (discovery via the repo's `.claude-plugin/marketplace.json`).
 
 ### Changed
 
@@ -15,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Quoted `argument-hint` YAML values in skill frontmatter so GitHub Copilot CLI ≥1.0.65 loads all skills ([#265](https://github.com/eigenwise/atomic-agents/pull/265)).
+- The repo's maintainer-only `release` skill no longer leaks into `npx skills` discovery (`metadata.internal: true`).
 
 ## [2.1.0] - 2026-04-29
 

--- a/claude-plugin/atomic-agents/README.md
+++ b/claude-plugin/atomic-agents/README.md
@@ -4,10 +4,12 @@ A Claude Code plugin that gives Claude deep, just-in-time knowledge of the [Atom
 
 ## What you get
 
-Two skills + two subagents, loaded on demand:
+Seven skills + two subagents, loaded on demand:
 
 - **`framework` skill** — auto-triggered when Claude sees atomic-agents code. Orients Claude on the framework and exposes eleven focused reference files (schemas, agents, tools, context providers, prompts, orchestration, memory, hooks, providers, project structure, testing). Progressive disclosure keeps the parent context lean.
-- **`new-app` skill** — slash-invokable scaffolder (`/atomic-agents:new-app`). Four short questions and produces a runnable project with the right `pyproject.toml`, environment file, and first agent.
+- **Four creation skills** — `create-atomic-schema`, `create-atomic-agent`, `create-atomic-tool`, `create-atomic-context-provider`. Each walks a clarify → write → verify → hand-off workflow for its component type, auto-triggering on the matching phrasing.
+- **`troubleshoot` skill** — auto-triggered on errors and tracebacks from atomic-agents code. Symptom table keyed on the framework's real error messages (provider role/mode mismatches, schema docstring enforcement, history misuse, MCP transports), each with a mechanical fix and a verification step.
+- **`new-app` skill** — slash-invokable scaffolder (`/atomic-agents:new-app`). Four short questions and produces a runnable project with the right `pyproject.toml`, environment file, first agent, and an `AGENTS.md` + `CLAUDE.md` pair so any coding assistant knows the conventions from the first commit.
 - **`atomic-explorer` subagent** — auto-triggered (or `Task`-invoked) when you ask to explore, map, or understand an existing atomic-agents codebase. Reads the project in isolated context and returns a compact architecture map (agents, tools, schemas, context providers, orchestration, essential-reading list) without polluting the parent thread with every file it had to open to build that map.
 - **`atomic-reviewer` subagent** — auto-triggered (or `Task`-invoked) when you ask for a review, audit, or check of atomic-agents code. Runs in isolated context with read-only tools so the file-exploration load never pollutes the parent thread. Focuses only on framework-specific concerns (BaseIOSchema invariants, Instructor wrapping, per-provider role and mode, context-provider I/O hygiene, orchestration hazards, common API misuses). Returns a single confidence-filtered structured report. Complements generic code review; does not replace it.
 

--- a/claude-plugin/atomic-agents/skills/framework/SKILL.md
+++ b/claude-plugin/atomic-agents/skills/framework/SKILL.md
@@ -74,6 +74,7 @@ For the four most common authoring tasks, dedicated atomic skills give a step-by
 | "create an agent" / "add another agent" / "wire up an `AtomicAgent`" | `atomic-agents:create-atomic-agent` |
 | "add a tool" / "wrap an API as a tool" / "build a `BaseTool`" | `atomic-agents:create-atomic-tool` |
 | "add a context provider" / "inject X into the prompt" / "wire up RAG" | `atomic-agents:create-atomic-context-provider` |
+| "my agent is broken / crashing / returning garbage" + a traceback or error | `atomic-agents:troubleshoot` |
 
 These skills auto-trigger on the matching phrasing. The reference files below are what they (and you) load for deeper material.
 
@@ -122,6 +123,10 @@ Scaffolding a brand-new project (fresh directory, `pyproject.toml`, first agent)
 Delegate to the `atomic-explorer` subagent when the project has more than a handful of atomic-agents files and the user asks to "explore", "map", "understand how X works", or similar. The subagent reads the relevant files in isolated context and returns a compact architecture map (agents, tools, schemas, context providers, orchestration, essential-reading list). Invoke via the `Task` tool with the scope (project root, module path, or feature) in the prompt.
 
 For a small project (a single `main.py` + one or two agents), reading the files directly in the main thread is fine — the isolation upside is thin.
+
+## When something is failing right now
+
+A concrete error, traceback, or wrong-output report routes to the `troubleshoot` skill — it carries a symptom table keyed on the framework's real error messages plus the per-provider failure modes. Review is for code that isn't currently on fire; troubleshoot is for code that is.
 
 ## When the user wants a review
 

--- a/claude-plugin/atomic-agents/skills/new-app/SKILL.md
+++ b/claude-plugin/atomic-agents/skills/new-app/SKILL.md
@@ -47,6 +47,8 @@ Create files in this order. Verify each step before proceeding.
 ├── .env.example
 ├── .gitignore
 ├── README.md
+├── AGENTS.md
+├── CLAUDE.md
 └── <project_name>/
     ├── __init__.py
     └── main.py
@@ -94,6 +96,42 @@ Per-provider AgentConfig knobs — match the Instructor factory mode on `AgentCo
 ### `README.md`
 
 Short. Include: what the project is, how to install (`uv sync` or `pip install -e .[dev]`), how to set the API key (`cp .env.example .env` and edit), how to run (`uv run python -m <project_name>.main` or equivalent).
+
+### `AGENTS.md` and `CLAUDE.md`
+
+Every scaffolded project ships agent instructions so any coding assistant (Cursor, Codex, Copilot, Gemini CLI, ...) knows the framework conventions from the first commit. `CLAUDE.md` contains exactly one line — `@AGENTS.md` — so Claude Code reads the same file without duplication.
+
+`AGENTS.md` template (substitute project specifics):
+
+```markdown
+# <Project Name>
+
+<One-line description from the agent-type answer.>
+
+Built with [Atomic Agents](https://github.com/eigenwise/atomic-agents) — a schema-driven
+framework on Instructor + Pydantic. Docs for LLMs:
+https://eigenwise.github.io/atomic-agents/llms.txt
+
+## Framework conventions
+
+- Import from the top-level package: `from atomic_agents import AtomicAgent, AgentConfig,
+  BaseIOSchema, BaseTool`; context pieces from `atomic_agents.context`.
+- Agents are `AtomicAgent[InputSchema, OutputSchema](config=AgentConfig(...))` — the type
+  parameters carry runtime information, keep them accurate.
+- The LLM client must be wrapped with Instructor before it goes into `AgentConfig.client`.
+- Every `BaseIOSchema` subclass needs a non-empty docstring and `Field(..., description=...)`
+  on each field — both flow into the LLM prompt.
+- Provider knobs (`temperature`, `max_tokens`, ...) go in `AgentConfig.model_api_parameters`.
+- Provider: <chosen provider>. <Provider-specific line from the matrix below, if any.>
+
+## Commands
+
+- Install: `uv sync` (or the pip equivalent chosen at scaffold time)
+- Run: `uv run python -m <project_name>.main`
+- Test: `uv run pytest`
+```
+
+Provider-specific lines for the template: Anthropic → "Requires `max_tokens` in `model_api_parameters`; `mode=Mode.TOOLS`." Gemini → "`assistant_role='model'` and `mode=Mode.GENAI_TOOLS`." Groq/Ollama/MiniMax → "`mode=Mode.JSON` on both the Instructor factory and `AgentConfig`." OpenAI/OpenRouter → omit.
 
 ## Phase 4 — Install and smoke-test
 

--- a/claude-plugin/atomic-agents/skills/troubleshoot/SKILL.md
+++ b/claude-plugin/atomic-agents/skills/troubleshoot/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: troubleshoot
+description: Diagnose and fix a failing or misbehaving Atomic Agents app — import errors, schema validation failures, empty or malformed LLM output, provider role/mode errors, history and context problems, MCP transport errors. Use when the user reports an error, traceback, or wrong behavior in atomic-agents code, asks "why is my agent not working / crashing / returning garbage", or pastes a `ValidationError`, `ImportError`, or provider API error from an atomic-agents project.
+---
+
+# Troubleshoot an Atomic Agents App
+
+Diagnostic workflow for the "it's broken" moment. Most atomic-agents failures are one of a dozen known causes with mechanical fixes. Match the symptom, apply the fix, verify by re-running.
+
+## Workflow
+
+1. **Capture the failure.** Get the exact traceback or wrong-output sample plus the code that produces it (agent construction, schemas, client wiring). If the user pasted only a fragment of the error, ask for the full traceback before guessing.
+2. **Match against the symptom table below.** The quoted strings are the framework's real messages — match on them.
+3. **Apply the fix and re-run** the failing snippet. Do not declare the problem solved without a passing re-run.
+4. **No match?** Load the reference for the failing area (table at the bottom) and reason from there. For a whole-codebase audit rather than one failure, delegate to the `atomic-reviewer` subagent instead.
+
+## Symptom table
+
+### Import and definition errors
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ImportError`/`ModuleNotFoundError` on `atomic_agents.lib.*`, `atomic_agents.agents.base_agent`, or `BaseAgent` | v1 import paths, removed in v2 | Import from the top level: `from atomic_agents import AtomicAgent, AgentConfig, BaseIOSchema, BaseTool`; context pieces from `atomic_agents.context` |
+| `ValueError: <Name> must have a non-empty docstring to serve as its description` at import time | `BaseIOSchema` subclass without a docstring | Add a docstring describing the schema — it flows into the LLM prompt, so write it for the model |
+| `ValidationError` when constructing `AgentConfig`, complaining about `client` | Raw provider SDK client passed; `AgentConfig.client` requires an Instructor-wrapped client | Wrap it: `instructor.from_openai(...)`, `instructor.from_anthropic(...)`, `instructor.from_genai(...)` |
+| `TypeError` about missing type parameters, or output typed as `BasicChatOutputSchema` when a custom schema was expected | `AtomicAgent` instantiated without generics | Write `AtomicAgent[InputSchema, OutputSchema](config=...)` — the type parameters carry runtime information (they drive Instructor's `response_model`) |
+
+### Provider errors at run time
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Anthropic error mentioning `max_tokens` is required | Anthropic requires it per request | `model_api_parameters={"max_tokens": 4096}` on `AgentConfig` |
+| Gemini error about invalid role / role ordering | Gemini names the assistant role `model` | `assistant_role="model"` on `AgentConfig`; use `instructor.from_genai(...)` with `mode=Mode.GENAI_TOOLS` and match `AgentConfig.mode` |
+| Empty output, `None` fields, or JSON-parse noise on Groq / Ollama / MiniMax | Provider needs JSON mode; factory and config modes disagree | Create the client with `Mode.JSON` and set `mode=Mode.JSON` on `AgentConfig` — the two must always match |
+| Works on OpenAI, breaks on another provider with no code change | Provider quirks live in `AgentConfig`, not the agent | Check the per-provider matrix in [framework/references/providers.md](../framework/references/providers.md) |
+
+### Wrong or degraded behavior (no exception)
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Pydantic `ValidationError` from inside `run()` after retries | Model can't satisfy the output schema | Improve field `description=`s and the schema docstring first; loosen over-tight constraints; only then consider a stronger model. Inspect attempts via the `parse:error` hook |
+| Agent "forgets" earlier turns | Fresh `ChatHistory` created per call, or none passed | Create one `ChatHistory` and reuse it across `run()` calls |
+| Context/cost grows without bound in long sessions | Unbounded history | Set `max_context_tokens` on `AgentConfig` — oldest turns are trimmed automatically |
+| Every `run()` is slow before the LLM call even starts | Blocking I/O in a context provider's `get_info()` | `get_info()` runs on every `run()`; move fetching out, cache, or make the provider hold precomputed state |
+| `history.load(...)` "doesn't work" | Called as a classmethod | `load` is an instance method that mutates in place: `history = ChatHistory(); history.load(saved)`. `dump()` returns a JSON string |
+
+### MCP interop
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `AttributeError: STREAMABLE_HTTP` | No such member | `MCPTransportType.HTTP_STREAM` (others: `SSE`, `STDIO`) |
+| MCP tools fetch but calls fail | Transport/endpoint mismatch | See MCP section of [framework/references/tools.md](../framework/references/tools.md) and the `mcp-agent` example |
+
+## Escalation map
+
+| Failing area | Load |
+|---|---|
+| Schema design, validators | [framework/references/schemas.md](../framework/references/schemas.md) |
+| Agent config, run modes, streaming | [framework/references/agents.md](../framework/references/agents.md) |
+| Provider wiring, roles, modes | [framework/references/providers.md](../framework/references/providers.md) |
+| History, persistence, multi-agent memory | [framework/references/memory.md](../framework/references/memory.md) |
+| Hooks, retries, telemetry | [framework/references/hooks.md](../framework/references/hooks.md) |
+| Tools, MCP | [framework/references/tools.md](../framework/references/tools.md) |
+| Orchestration between agents | [framework/references/orchestration.md](../framework/references/orchestration.md) |
+
+Related skills: `framework` (general guidance, auto-triggers), `create-atomic-agent` / `create-atomic-schema` / `create-atomic-tool` / `create-atomic-context-provider` (building rather than fixing). For a review of code that isn't currently failing, use the `atomic-reviewer` subagent.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -439,6 +439,44 @@ To run any of these examples:
    uv run python chatbot.py
    ```
 
+## Set Up Your Project for AI Coding Assistants
+
+If you build with an AI assistant (Claude Code, Cursor, Copilot, Codex, Gemini CLI, ...), two small steps make it know Atomic Agents instead of guessing at the API:
+
+1. **Install the agent skills** — guided workflows for creating schemas, agents, tools, and context providers, plus a troubleshooting diagnostic:
+
+   ```bash
+   # Claude Code
+   /plugin marketplace add eigenwise/atomic-agents
+   /plugin install atomic-agents@eigenwise
+
+   # Any other skills-compatible assistant
+   npx skills add eigenwise/atomic-agents
+   ```
+
+2. **Drop an `AGENTS.md` into your project root** so every assistant picks up the framework conventions. Add a `CLAUDE.md` containing just `@AGENTS.md` so Claude Code reads the same file:
+
+   ```markdown
+   # My Project
+
+   Built with [Atomic Agents](https://github.com/eigenwise/atomic-agents) — a schema-driven
+   framework on Instructor + Pydantic. Docs for LLMs:
+   https://eigenwise.github.io/atomic-agents/llms.txt
+
+   ## Framework conventions
+
+   - Import from the top-level package: `from atomic_agents import AtomicAgent, AgentConfig,
+     BaseIOSchema, BaseTool`; context pieces from `atomic_agents.context`.
+   - Agents are `AtomicAgent[InputSchema, OutputSchema](config=AgentConfig(...))` — the type
+     parameters carry runtime information, keep them accurate.
+   - The LLM client must be wrapped with Instructor before it goes into `AgentConfig.client`.
+   - Every `BaseIOSchema` subclass needs a non-empty docstring and `Field(..., description=...)`
+     on each field — both flow into the LLM prompt.
+   - Provider knobs (`temperature`, `max_tokens`, ...) go in `AgentConfig.model_api_parameters`.
+   ```
+
+Projects scaffolded with the `new-app` skill get both files automatically. Assistants can also pull the full docs from [llms.txt](https://eigenwise.github.io/atomic-agents/llms.txt) or query them via [Context7](https://context7.com/eigenwise/atomic-agents).
+
 ## Next Steps
 
 After trying these examples, you can:


### PR DESCRIPTION
## What

Final slice of the AI DX upgrade (after #267, #268). New consumer-facing plugin content, shipped as plugin 2.2.0.

**`troubleshoot` skill.** The everyday loop where generic assistants get the framework wrong is "my agent errors or returns garbage." The new skill carries a symptom table keyed on the framework's *real* error messages, pulled from source, not paraphrased: the `BaseIOSchema` docstring enforcement string, `AgentConfig.client` Pydantic validation (raw SDK client), per-provider role/mode failures (Gemini `assistant_role`, Anthropic `max_tokens`, Groq/Ollama JSON mode), `HTTP_STREAM` vs the nonexistent `STREAMABLE_HTTP`, history misuse, unbounded context (fix: `max_context_tokens`), blocking `get_info()`. Every entry has a mechanical fix and the workflow mandates a re-run before declaring victory. `framework` routes concrete errors here; an escalation map points into the reference files for unmatched cases.

**`new-app` scaffolds agent instructions.** Every generated project now gets an `AGENTS.md` (framework conventions + a provider-specific quirk line) and a one-line `CLAUDE.md` containing `@AGENTS.md` — the documented, Windows-safe pattern (Claude Code doesn't read AGENTS.md natively, verified against current docs). Quickstart guide gets the same drop-in pair for existing projects, plus both skill install paths.

**Housekeeping.** Plugin README's "What you get" still described the 2.0 layout (two skills); it now lists all seven. `plugin.json`/`marketplace.json` → 2.2.0, changelog folds the unreleased items (rebrand, MiniMax M3, Copilot CLI fix, release-skill hiding) into the release.

## Verified

- `claude plugin validate` passes
- `npx skills add <local-path> --list`: exactly the 7 plugin skills, maintainer `release` skill still hidden
- Troubleshoot's error strings grepped from framework source (`base_io_schema.py`, `mcp_definition_service.py`, `atomic_agent.py`, `chat_history.py`)
- Relative reference links resolve (`../framework/references/*.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)